### PR TITLE
fix: allow experiemental and avoid warning about missing dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.util.EnumSet
+import org.jetbrains.intellij.tasks.RunPluginVerifierTask.*
 
 fun properties(key: String) = project.findProperty(key).toString()
 
@@ -112,5 +114,18 @@ tasks {
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
         channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
+    }
+
+    runPluginVerifier {
+        // we unfortunately use experimental apis so have to mark it as non-failure to have build pass
+        val customFailureLevel = EnumSet.complementOf(
+                EnumSet.of(
+                        FailureLevel.DEPRECATED_API_USAGES,
+                        FailureLevel.EXPERIMENTAL_API_USAGES,
+                        FailureLevel.INTERNAL_API_USAGES,
+                        FailureLevel.NOT_DYNAMIC
+                )
+        )
+        failureLevel.set(customFailureLevel)
     }
 }

--- a/src/main/resources/META-INF/jbang-dependency-update-integration.xml
+++ b/src/main/resources/META-INF/jbang-dependency-update-integration.xml
@@ -2,4 +2,5 @@
     <extensions defaultExtensionNs="com.intellij">
         <externalSystem.dependencyModifier implementation="dev.jbang.idea.externalSystem.JbangDependencyModifier"/>
     </extensions>
+    <depends>com.intellij.externalSystem.dependencyUpdater</depends>
 </idea-plugin>


### PR DESCRIPTION
Automatic build been failing for weeks - this PR tries to improve it by a) add missing dependency declaration in .XML b) make it so experimental API usage does not fail verification.

Unfortunately this is not enough as `gradle runPluginVerifier` still reports the following incompatibilities with ic-213 (it works with ic-212):

```
 #Package 'com.intellij.buildsystem' is not found
 #Package 'org.jetbrains.idea.reposearch' is not found
```

I do not know why these are set to be not found in IC-213, do you know @linux-china ?



 