### PR TITLE
restore unreleased to not break automatic setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # jbang-idea-plugin Changelog
 
+## [Unreleased]
+
+
 ## [0.13.0]
 
 - GAV completion with last version support


### PR DESCRIPTION
This restores the [Unreleased] changelog entry so the automatic ci and release setup works.

We just need to add entries under unrelated, use pull-request (NOT direct commits) and then on merge/review we get a Draft release of the next version which when made to a release will get published automatically. This also enables us to do automatic announce on twitter etc. Should not be uploading manually/individually to the marketplace.

Please see https://github.com/JetBrains/intellij-platform-plugin-template#changelog-maintenance and the following sections on how this works.

Thanks!