### PR TITLE
fix: do not put things in test scope

### DIFF
--- a/src/main/kotlin/dev/jbang/idea/actions/SyncDependenciesAction.kt
+++ b/src/main/kotlin/dev/jbang/idea/actions/SyncDependenciesAction.kt
@@ -363,11 +363,8 @@ class SyncDependenciesAction : AnAction() {
         ProjectJdkTable.getInstance().getSdksOfType(JavaSdk.getInstance()).firstOrNull { it.name == version }
 
     private fun replaceJBangModuleLib(module: Module, scriptName: String, newDependencies: List<String>) {
-        val libName = if (scriptName.substring(0, scriptName.lastIndexOf('.')).lowercase().endsWith("test")) {
-            "${module.name}-jbangTest"
-        } else {
-            "${module.name}-jbang"
-        }
+        val libName = "${module.name}-jbang"
+
         // remove jbang library
         val moduleRootManager = ModuleRootManager.getInstance(module)
         val modifiableModel = moduleRootManager.modifiableModel
@@ -378,11 +375,7 @@ class SyncDependenciesAction : AnAction() {
         }
         // add jbang dependencies
         if (newDependencies.isNotEmpty()) {
-            if (libName.endsWith("Test")) {
-                ModuleRootModificationUtil.addModuleLibrary(module, libName, newDependencies.map { "jar://${it}!/" }.toList(), listOf(), DependencyScope.TEST)
-            } else {
-                ModuleRootModificationUtil.addModuleLibrary(module, libName, newDependencies.map { "jar://${it}!/" }.toList(), listOf())
-            }
+            ModuleRootModificationUtil.addModuleLibrary(module, libName, newDependencies.map { "jar://${it}!/" }.toList(), listOf())
         }
     }
 


### PR DESCRIPTION
Fixes #42 

Remove the code that arbitrary put a dependency into test scope meaning "run" main does not get the dependencies added.

Can't see a case where this would ever be wanted. If we would ever need test support it should because the file is inside a folder marked as a test folder not because it coincidentally has "test" in its file name.