### PR TITLE
feat: enable download sources

### DIFF
--- a/src/main/kotlin/dev/jbang/idea/JBangCli.kt
+++ b/src/main/kotlin/dev/jbang/idea/JBangCli.kt
@@ -22,7 +22,7 @@ object JBangCli {
     @Throws(Exception::class)
     fun resolveScriptDependencies(scriptFilePath: String): List<String> {
         val jbangCmd = getJBangCmdAbsolutionPath()
-        val output = ProcessExecutor().command(jbangCmd, "info", "classpath", "--quiet", "--fresh", scriptFilePath)
+        val output = ProcessExecutor().environment("JBANG_DOWNLOAD_SOURCES", "true").command(jbangCmd, "info", "classpath", "--quiet", "--fresh", scriptFilePath)
             .readOutput(true)
             .execute()
             .outputUTF8()
@@ -32,7 +32,7 @@ object JBangCli {
     @Throws(Exception::class)
     fun resolveScriptInfo(jbangScriptFilePath: String): ScriptInfo {
         val jbangCmd = getJBangCmdAbsolutionPath()
-        val allText = ProcessExecutor().command(jbangCmd, "info", "tools", "--quiet", "--fresh", jbangScriptFilePath)
+        val allText = ProcessExecutor().environment("JBANG_DOWNLOAD_SOURCES", "true").command(jbangCmd, "info", "tools", "--quiet", "--fresh", jbangScriptFilePath)
             .readOutput(true)
             .execute()
             .outputUTF8()


### PR DESCRIPTION
this is to have jbang idea intellij plugin give hint to jbang that it should download sources.

does it by setting JBANG_DOWNLOAD_SOURCES=true when invoking jbang info commands.

Works with not yet released jbang but it will be out soon and this flag does not hurt older jbang versions thus might as well get it added so the plugin is ready. 