### PR TITLE
honor JBANG_HOME, PATH and ~/.jbang/bin in that order 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 
+- Fixed: honor JBANG_HOME, PATH and ~/.jbang/bin in that order when searching for jbang command
 ## [0.24.1]
 
 - Fixed: Compatible with IntelliJ IDEA 2023.1

--- a/src/main/kotlin/dev/jbang/idea/JBang.kt
+++ b/src/main/kotlin/dev/jbang/idea/JBang.kt
@@ -5,6 +5,9 @@ package dev.jbang.idea
 import com.intellij.openapi.util.IconLoader
 import com.intellij.openapi.util.SystemInfo
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 val jbangIcon = IconLoader.getIcon("icons/jbang-16x16.png", JBangCli::class.java)
 val jbangIcon12 = IconLoader.getIcon("icons/jbang-12x12.png", JBangCli::class.java)
@@ -21,28 +24,38 @@ const val JBANG_DECLARE_FULL = "///usr/bin/env jbang \"\$0\" \"\$@\" ; exit \$?"
 val ALL_DIRECTIVES = listOf("JAVA", "DEPS", "GAV", "FILES", "SOURCES", "DESCRIPTION", "REPOS", "JAVAC_OPTIONS", "JAVA_OPTIONS", "JAVAAGENT", "CDS", "KOTLIN", "GROOVY")
 val ALL_EXT_NAMES = listOf(".java", ".kt", ".jsh", ".groovy")
 
-fun getJBangCmdAbsolutionPath(): String {
-    val userHome = System.getProperty("user.home")
-    return if (SystemInfo.isWindows) {
-        if (File(System.getenv("JBANG_HOME") ?: "", "bin/jbang.cmd").exists()) {
-            File(System.getenv("JBANG_HOME") ?: "", "bin/jbang.cmd").absolutePath
-        } else if (File(userHome, ".sdkman/candidates/jbang/current/bin/jbang.cmd").exists()) {
-            File(userHome, ".sdkman/candidates/jbang/current/bin/jbang.cmd").absolutePath
-        } else {
-            File(userHome, ".jbang/bin/jbang.cmd").absolutePath
-        }
-    } else {
-        if (File(System.getenv("JBANG_HOME") ?: "", "bin/jbang").exists()) {
-            File(System.getenv("JBANG_HOME") ?: "", "bin/jbang").absolutePath
-        } else if (File("/usr/local/bin/jbang").exists()) {
-            "/usr/local/bin/jbang"
-        } else if (File(userHome, ".sdkman/candidates/jbang/current/bin/jbang").exists()) {
-            File(userHome, ".sdkman/candidates/jbang/current/bin/jbang").absolutePath
-        } else {
-            File(userHome, ".jbang/bin/jbang").absolutePath
+fun findCommandInPath(command: String): Path? {
+    val path = System.getenv("PATH") ?: return null
+    val pathElements = path.split(File.pathSeparator)
+
+    for (pathElement in pathElements) {
+        val commandFile = Path.of(pathElement, command)
+        if (Files.exists(commandFile) && Files.isExecutable(commandFile)) {
+            return commandFile
         }
     }
+
+    return null
 }
+fun getJBangCmdAbsolutionPath(): String {
+    val userHome = System.getProperty("user.home")
+    val jbangHome = System.getenv("JBANG_HOME")
+    val jbangScript = if (SystemInfo.isWindows) "jbang.cmd" else "jbang"
+    var actualJBangScript: Path?
+
+    if(jbangHome!=null) {
+        actualJBangScript = Path.of(jbangHome, "bin/$jbangScript")
+    } else {
+        actualJBangScript = findCommandInPath(jbangScript)
+    }
+
+    if(actualJBangScript==null) {
+        actualJBangScript = Path.of(userHome, ".jbang/bin/$jbangScript")
+    }
+
+    return actualJBangScript?.toAbsolutePath().toString()
+}
+
 
 fun isJBangScriptFile(fileName: String): Boolean {
     val extName = if (fileName.contains('.')) {


### PR DESCRIPTION
…for jbang command

this makes it much more consistent to find the jbang command and remove need to have special sdkman/scoop search cases.