### PR TITLE
Enable use at EAP versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@ pluginVersion = 0.24.5
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 231
-pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC


### PR DESCRIPTION
`pluginUntilBuild` is an optional property. My opinion: Enable it for all future versions until someone says, it does not work.

Currently, I cannot use it in 2024.2 EAP; this PR should fix it.

![image](https://github.com/jbangdev/jbang-idea/assets/1366654/f2bb8586-4171-489e-90aa-ca48d3410a35)
