### PR TITLE
fix: inject parent environment variables in JBang process

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,6 +118,6 @@ tasks {
         // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
+        channels = providers.gradleProperty("pluginVersion").map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ pluginSinceBuild = 231
 pluginUntilBuild = 242.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
-platformType = IU
+platformType = IC
 platformVersion = 2023.3.4
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/src/main/kotlin/dev/jbang/idea/JBang.kt
+++ b/src/main/kotlin/dev/jbang/idea/JBang.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.util.SystemInfo
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 
 val jbangIcon = IconLoader.getIcon("icons/jbang-16x16.png", JBangCli::class.java)
 val jbangIcon12 = IconLoader.getIcon("icons/jbang-12x12.png", JBangCli::class.java)
@@ -25,7 +24,7 @@ val ALL_DIRECTIVES = listOf("JAVA", "DEPS", "GAV", "FILES", "SOURCES", "DESCRIPT
 val ALL_EXT_NAMES = listOf(".java", ".kt", ".jsh", ".groovy")
 
 fun findCommandInPath(command: String): Path? {
-    val path = System.getenv("PATH") ?: return null
+    val path = PARENT_ENV_VAR["PATH"] ?: return null
     val pathElements = path.split(File.pathSeparator)
 
     for (pathElement in pathElements) {
@@ -39,7 +38,7 @@ fun findCommandInPath(command: String): Path? {
 }
 fun getJBangCmdAbsolutionPath(): String {
     val userHome = System.getProperty("user.home")
-    val jbangHome = System.getenv("JBANG_HOME")
+    val jbangHome = PARENT_ENV_VAR["JBANG_HOME"]
     val jbangScript = if (SystemInfo.isWindows) "jbang.cmd" else "jbang"
     var actualJBangScript: Path?
 

--- a/src/main/kotlin/dev/jbang/idea/JBangCli.kt
+++ b/src/main/kotlin/dev/jbang/idea/JBangCli.kt
@@ -3,26 +3,43 @@ package dev.jbang.idea
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.*
+import com.intellij.openapi.diagnostic.Logger
+import dev.jbang.idea.JBangCli.parentEnvironment
 import org.zeroturnaround.exec.ProcessExecutor
 import java.io.File
 
+public val PARENT_ENV_VAR = parentEnvironment();
+
 object JBangCli {
 
+    private val log: Logger = Logger.getInstance(JBangCli::class.java)
+
     @Throws(Exception::class)
-    fun listJBangTemplates(): List<String> {
+    fun listJBangTemplates(): List<TemplateInfo> {
         val jbangCmd = getJBangCmdAbsolutionPath()
-        return ProcessExecutor().command(jbangCmd, "template", "list")
+        val output = ProcessExecutor()
+            .command(jbangCmd, "template", "list", "--format=json")
+            .environment(parentEnvironment())
             .environment("NO_COLOR", "true")
             .readOutput(true)
             .execute()
             .outputUTF8()
-            .lines()
+
+        val objectMapper = jacksonObjectMapper().apply {
+            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        }
+        return objectMapper.readValue(output)
     }
 
     @Throws(Exception::class)
     fun resolveScriptDependencies(scriptFilePath: String): List<String> {
         val jbangCmd = getJBangCmdAbsolutionPath()
-        val output = ProcessExecutor().environment("JBANG_DOWNLOAD_SOURCES", "true").command(jbangCmd, "info", "classpath", "--quiet", "--fresh", scriptFilePath)
+        val output = ProcessExecutor()
+            .command(jbangCmd, "info", "classpath", "--quiet", "--fresh", scriptFilePath)
+            .environment(parentEnvironment())
+            .environment("JBANG_DOWNLOAD_SOURCES", "true")
             .readOutput(true)
             .execute()
             .outputUTF8()
@@ -32,7 +49,10 @@ object JBangCli {
     @Throws(Exception::class)
     fun resolveScriptInfo(jbangScriptFilePath: String): ScriptInfo {
         val jbangCmd = getJBangCmdAbsolutionPath()
-        val allText = ProcessExecutor().environment("JBANG_DOWNLOAD_SOURCES", "true").command(jbangCmd, "info", "tools", "--quiet", "--fresh", jbangScriptFilePath)
+        val allText = ProcessExecutor()
+            .command(jbangCmd, "info", "tools", "--quiet", "--fresh", jbangScriptFilePath)
+            .environment(parentEnvironment())
+            .environment("JBANG_DOWNLOAD_SOURCES", "true")
             .readOutput(true)
             .execute()
             .outputUTF8()
@@ -46,9 +66,17 @@ object JBangCli {
     fun generateScriptFromTemplate(templateName: String, scriptName: String, destDir: String) {
         val jbangCmd = getJBangCmdAbsolutionPath()
         val filePath = File(destDir, scriptName).absolutePath
-        ProcessExecutor()
+        val output = ProcessExecutor()
             .command(jbangCmd, "init", "--template", templateName, "--force", filePath)
+            .environment(parentEnvironment())
+            .readOutput(true)
             .execute()
+            .outputUTF8()
+        log.info(output)
+    }
+
+    fun parentEnvironment(): Map<String, String> {
+       return GeneralCommandLine().withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE).effectiveEnvironment
     }
 
 }

--- a/src/main/kotlin/dev/jbang/idea/actions/CreateFromTemplateAction.kt
+++ b/src/main/kotlin/dev/jbang/idea/actions/CreateFromTemplateAction.kt
@@ -22,10 +22,11 @@ class CreateFromTemplateAction : AnAction(), DumbAware {
             val dialogWrapper = JBangTemplatesDialogWrapper(templates)
             if (dialogWrapper.showAndGet()) {
                 var scriptName = dialogWrapper.getScriptFileName()
-                if (!scriptName.contains('.')) {
-                    scriptName = "${scriptName}.java"
-                }
                 val templateName = dialogWrapper.getTemplateName()
+                if (!scriptName.contains('.')) {
+                    val ext = inferExtension(templateName)
+                    scriptName = "${scriptName}.${ext}"
+                }
                 if (scriptName.isNotEmpty()) {
                     ApplicationManager.getApplication().runWriteAction {
                         val directory = e.getData(CommonDataKeys.VIRTUAL_FILE)!!
@@ -69,5 +70,14 @@ class CreateFromTemplateAction : AnAction(), DumbAware {
             val jbangNotificationGroup = NotificationGroupManager.getInstance().getNotificationGroup("JBang Failure")
             jbangNotificationGroup.createNotification("Failed to get JBang templates", errorText, NotificationType.ERROR).notify(project)
         }
+    }
+
+    private fun inferExtension(name: String): String {
+        val extension = if (name.contains('.')) {
+            name.substringAfterLast('.')
+        } else {
+            "java"
+        }
+        return extension
     }
 }

--- a/src/main/kotlin/dev/jbang/idea/actions/JBangTemplatesDialogWrapper.kt
+++ b/src/main/kotlin/dev/jbang/idea/actions/JBangTemplatesDialogWrapper.kt
@@ -3,10 +3,11 @@ package dev.jbang.idea.actions
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.LabeledComponent
+import dev.jbang.idea.TemplateInfo
 import javax.swing.*
 
 
-class JBangTemplatesDialogWrapper(private val templates: List<String>) : DialogWrapper(true) {
+class JBangTemplatesDialogWrapper(private val templates: List<TemplateInfo>) : DialogWrapper(true) {
     private var myScriptName: LabeledComponent<JTextField> = LabeledComponent()
     private var templateList: LabeledComponent<JComboBox<String>> = LabeledComponent()
 
@@ -29,7 +30,7 @@ class JBangTemplatesDialogWrapper(private val templates: List<String>) : DialogW
     }
 
     private fun createTemplateComboBox(): JComboBox<String> {
-        return ComboBox(this.templates.toTypedArray())
+        return ComboBox(this.templates.map { t -> t.name }.toTypedArray())
     }
 
     override fun getPreferredFocusedComponent(): JComponent {

--- a/src/main/kotlin/dev/jbang/idea/models.kt
+++ b/src/main/kotlin/dev/jbang/idea/models.kt
@@ -31,3 +31,9 @@ class ResourceFile {
     var backingResource: String? = null
     var target: String? = null
 }
+
+class TemplateInfo {
+    var name: String? = null
+    var fullName: String? = null
+    var description: String? = null
+}


### PR DESCRIPTION
Fixes #73

- **build: allow build against Java 21 and IC**
- **fix: inject parent environment variables in JBang process**

Also fixes fetching JBang templates and infering new script extension