### PR TITLE
Add a line in features describing the right-click sync deps feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following features are available:
 * JBang directives completion:  for example `//DEPS`, `//SOURCES`
 * Sync Dependencies between JBang and Gradle
 * Sync Dependencies to IDEA's module when using `idea .` to open JBang project
+* Sync Dependencies to IDEA's module by right-clicking in the JBang script header area and choosing "Sync JBang DEPS to Module"
 * JBang Run Line Marker for `///usr/bin/env jbang`
 * Java scratch file support
 * Run Configuration support: run JBang script by right click


### PR DESCRIPTION
Since I had to go looking in the issues for how to sync dependencies on a fork of the jdysk repo, here is what I would add to the features list to answer the https://github.com/jbangdev/jbang-idea/issues/102#issuecomment-2715507189 comment.

Related to #102