### PR TITLE
fix: ignore JVM warnings when parsing JBang output

### DIFF
--- a/src/main/kotlin/dev/jbang/idea/JBangCli.kt
+++ b/src/main/kotlin/dev/jbang/idea/JBangCli.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.process.*
 import com.intellij.openapi.diagnostic.Logger
 import dev.jbang.idea.JBangCli.parentEnvironment
 import org.zeroturnaround.exec.ProcessExecutor
@@ -20,7 +19,7 @@ object JBangCli {
     fun listJBangTemplates(): List<TemplateInfo> {
         val jbangCmd = getJBangCmdAbsolutionPath()
         val output = ProcessExecutor()
-            .command(jbangCmd, "template", "list", "--format=json")
+            .command(jbangCmd, "template", "list", "--format=json", "--quiet")
             .environment(parentEnvironment())
             .environment("NO_COLOR", "true")
             .readOutput(true)
@@ -30,7 +29,32 @@ object JBangCli {
         val objectMapper = jacksonObjectMapper().apply {
             configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         }
-        return objectMapper.readValue(output)
+        return objectMapper.readValue(cleanOutput(output, true))
+    }
+
+    internal fun cleanOutput(output: String, isJson: Boolean = false): String {
+        val lines = output.lines()
+        if (isJson) {
+            val jsonStartIndex = lines.indexOfFirst { line ->
+                val trimmed = line.trimStart()
+                // Heuristic: Is this the start of a JSON payload?
+                // 1. Starts with "{" (JVM warnings almost never do)
+                // 2. Starts with "[" BUT is followed by a valid JSON object or string start like "{", '"', an empty array "]", or is just empty.
+                // Note: This intentionally ignores JSON arrays of primitives like `[1]` or `[true]` 
+                // because JBang only ever outputs arrays of objects `[{...}]` or strings `["..."]`.
+                trimmed.startsWith("{") || 
+                    (trimmed.startsWith("[") && trimmed.substring(1).trimStart().let { it.isEmpty() || it.startsWith("{") || it.startsWith("\"") || it.startsWith("]") })
+            }
+            return if (jsonStartIndex >= 0) {
+                lines.subList(jsonStartIndex, lines.size).joinToString("\n")
+            } else {
+                output
+            }
+        }
+
+        // For classpath, we expect the payload to be the last non-empty line.
+        // JVM warnings are printed before it.
+        return lines.lastOrNull { it.isNotBlank() }?.trim() ?: output
     }
 
     @Throws(Exception::class)
@@ -43,7 +67,7 @@ object JBangCli {
             .readOutput(true)
             .execute()
             .outputUTF8()
-        return output.split(File.pathSeparator).filter { !it.contains(".jbang") }.map { it.trim() }
+        return cleanOutput(output).split(File.pathSeparator).filter { !it.contains(".jbang") }.map { it.trim() }
     }
 
     @Throws(Exception::class)
@@ -59,7 +83,7 @@ object JBangCli {
         val objectMapper = jacksonObjectMapper().apply {
             configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         }
-        return objectMapper.readValue(allText)
+        return objectMapper.readValue(cleanOutput(allText, true))
     }
 
     @Throws(Exception::class)

--- a/src/test/kotlin/dev/jbang/idea/JBangCliTest.kt
+++ b/src/test/kotlin/dev/jbang/idea/JBangCliTest.kt
@@ -1,0 +1,178 @@
+package dev.jbang.idea
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class JBangCliTest {
+
+    @Test
+    fun testCleanOutputWithJson() {
+        val rawOutput = """
+            Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
+            WARNING: An illegal reflective access operation has occurred
+            {
+              "dependencies": ["hello.jar"]
+            }
+        """.trimIndent()
+        
+        val expected = """
+            {
+              "dependencies": ["hello.jar"]
+            }
+        """.trimIndent()
+
+        val actual = JBangCli.cleanOutput(rawOutput, isJson = true)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testCleanOutputWithJsonArray() {
+        val rawOutput = """
+            Picked up _JAVA_OPTIONS: -XX:+PrintCommandLineFlags
+            -XX:ConcGCThreads=2 -XX:G1ConcRefinementThreads=8 -XX:InitialHeapSize=536870912 
+            [
+              {
+                "name": "agent"
+              }
+            ]
+        """.trimIndent()
+        
+        val expected = """
+            [
+              {
+                "name": "agent"
+              }
+            ]
+        """.trimIndent()
+
+        val actual = JBangCli.cleanOutput(rawOutput, isJson = true)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testCleanOutputWithWarningContainingBracket() {
+        val rawOutput = """
+            WARNING: Illegal access [module java.base]
+            {
+              "success": true
+            }
+        """.trimIndent()
+        
+        val expected = """
+            {
+              "success": true
+            }
+        """.trimIndent()
+
+        val actual = JBangCli.cleanOutput(rawOutput, isJson = true)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testCleanOutputWithGcLogs() {
+        val rawOutput = """
+            Picked up _JAVA_OPTIONS: -Xlog:gc
+            [0.006s][info][gc] Using G1
+            [0.247s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 27M->7M(520M) 1.834ms
+            {
+              "success": true
+            }
+        """.trimIndent()
+        
+        val expected = """
+            {
+              "success": true
+            }
+        """.trimIndent()
+
+        val actual = JBangCli.cleanOutput(rawOutput, isJson = true)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testCleanOutputWithClasspath() {
+        val rawOutput = """
+            Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
+            WARNING: An illegal reflective access operation has occurred
+            /path/to/a.jar:/path/to/b.jar
+        """.trimIndent()
+        
+        val expected = "/path/to/a.jar:/path/to/b.jar"
+
+        val actual = JBangCli.cleanOutput(rawOutput, isJson = false)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testCleanOutputWithCompactJsonAndWarnings() {
+        val rawOutput = """
+            Picked up _JAVA_OPTIONS: -Xlog:gc
+            [0.006s][info][gc] Using G1
+            {"success": true}
+        """.trimIndent()
+        
+        val expected = """{"success": true}"""
+
+        val actual = JBangCli.cleanOutput(rawOutput, isJson = true)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testCleanOutputWithCompactJsonArrayAndWarnings() {
+        val rawOutput = """
+            Picked up _JAVA_OPTIONS: -Xlog:gc
+            [0.006s][info][gc] Using G1
+            [{"name": "agent"}]
+        """.trimIndent()
+        
+        val expected = """[{"name": "agent"}]"""
+
+        val actual = JBangCli.cleanOutput(rawOutput, isJson = true)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testCleanOutputWithDeceptiveWarningAndEmptyLines() {
+        val rawOutput = "A\nB\nC\nD\nWarning { \n\n\n\n{\n  \"success\": true\n}"
+        val expected = "{\n  \"success\": true\n}"
+        val actual = JBangCli.cleanOutput(rawOutput, isJson = true)
+        assertEquals(expected, actual) 
+    }
+
+    @Test
+    fun testCleanOutputWithEmptyArray() {
+        val rawOutput = "WARNING: something\n[]"
+        val expected = "[]"
+        val actual = JBangCli.cleanOutput(rawOutput, isJson = true)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testCleanOutputJsonWithoutWarnings() {
+        val jsonOutput = """{"key": "value"}"""
+        assertEquals(jsonOutput, JBangCli.cleanOutput(jsonOutput, isJson = true))
+    }
+
+    @Test
+    fun testCleanOutputClasspathWithoutWarnings() {
+        val classpathOutput = "/path/to/a.jar"
+        assertEquals(classpathOutput, JBangCli.cleanOutput(classpathOutput, isJson = false))
+    }
+
+    @Test
+    fun testCleanOutputEmptyOrOnlyWarnings() {
+        val emptyOutput = ""
+        assertEquals("", JBangCli.cleanOutput(emptyOutput, isJson = true))
+        assertEquals("", JBangCli.cleanOutput(emptyOutput, isJson = false))
+
+        val onlyWarnings = """
+            Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
+            WARNING: An illegal reflective access operation has occurred
+        """.trimIndent()
+        
+        // When there is no JSON payload found, it should return the original string or fallback gracefully
+        assertEquals(onlyWarnings, JBangCli.cleanOutput(onlyWarnings, isJson = true))
+        // For classpath, it will return the last line, which is the last warning
+        assertEquals("WARNING: An illegal reflective access operation has occurred", JBangCli.cleanOutput(onlyWarnings, isJson = false))
+    }
+}


### PR DESCRIPTION
Fixes #147. Filter out JVM diagnostic messages and GC logs from JBang standard output prior to JSON and classpath parsing.