### PR TITLE
docs: update outdated script creation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following features are available:
 * Define JBang location if not found in PATH or JBANG_HOME
 * JSON Schema for jbang-catalog.json and code completion for `script-ref`
 * JDKs sync with JBang: sync JDKs from JBang to IntelliJ IDEA
-* JBang script creation from file templates: New -> JBang Script
+* JBang script creation from file templates by right-clicking in the Project View: New -> JBang Script
 * JBang directives completion:  for example `//DEPS`, `//SOURCES`
 * Sync Dependencies between JBang and Gradle
 * JBang Run Line Marker for `///usr/bin/env jbang`

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -23,7 +23,7 @@ The following features are available:
 * JBang project wizard: create JBang project by IDEA project wizard
 * JSON Schema for jbang-catalog.json and code completion for `script-ref`
 * JDKs sync with JBang: sync JDKs from JBang to IntelliJ IDEA
-* JBang script creation from file templates: New -> JBang Script
+* JBang script creation from file templates by right-clicking in the Project View: New -> JBang Script
 * JBang directives completion:  for example `//DEPS`, `//SOURCES`
 * Sync Dependencies between JBang and Gradle
 * Sync Dependencies to IDEA's module when using `idea .` to open JBang project

--- a/src/main/kotlin/dev/jbang/idea/ui/UsagePanel.kt
+++ b/src/main/kotlin/dev/jbang/idea/ui/UsagePanel.kt
@@ -5,7 +5,7 @@ import javax.swing.JTextArea
 class UsagePanel constructor(prefix: String) : JTextArea() {
     private val jbangUsage = """- Create a JBang file, such as Kotlin, Java, or Groovy file.
 - You might need to install JBang from https://www.jbang.dev/download/
-- A new file can be created from a template (File | New | JBang Script)
+- A new file can be created from a template by right-clicking in the Project View (New | JBang Script)
 - JBang script should contain `///usr/bin/env jbang "${'$'}0" "${'$'}@" ; exit ${'$'}?`
 - JBang script code can be placed anywhere
 


### PR DESCRIPTION
Fixes #149. Updates the JBang Tool Window, README, and documentation to correctly state that JBang scripts are created via the Project View context menu.