### PR TITLE
fix: support IntelliJ IDEA 2026.2 (#155)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
           cache: gradle
 
       # Set environment variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           echo "::set-output name=changelog::$CHANGELOG"
           echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
 
-          ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
+          ./gradlew printProductsReleases # prepare list of IDEs for Plugin Verifier
 
       # Run tests
       - name: Run Tests
@@ -88,7 +88,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
-          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
+          key: plugin-verifier-${{ hashFiles('build/printProductsReleases.txt') }}
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       #      - name: Run Plugin Verification tasks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      # Validate wrapper
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@b5418f5a58f5fd2eb486dd7efb368fe7be7eae45 # v2
 
       # Setup Java 17 environment for the next steps
       - name: Setup Java

--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ modules.xml
 .gradle
 build/
 
+# IntelliJ Platform Gradle Plugin 2.x cache
+.intellijPlatform/
+
 # Ignore Gradle GUI config
 gradle-app.setting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix: Support IntelliJ IDEA 2026.2. `Sync Dependencies` no longer throws `NoClassDefFoundError` (#155); migrated off the removed `org.jetbrains.kotlin.idea.util.projectStructure` internal APIs to IntelliJ Platform APIs.
 - Fix: Migrate GAV `//DEPS` completion from the removed `reposearch` `DependencySearchService` to the new `DependencyCompletionService`.
+- Fix: Defer `parentEnvironment` initialization to avoid service access during class init (`<clinit>`).
+- Fix: Replace removed `AllIcons.Actions.Run_anything` icon with `AllIcons.Actions.Execute`.
 - Build: Migrate to IntelliJ Platform Gradle Plugin 2.x. Minimum supported IDE is now 2026.2 (build 262, JBR 25).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+- Fix: Support IntelliJ IDEA 2026.2. `Sync Dependencies` no longer throws `NoClassDefFoundError` (#155); migrated off the removed `org.jetbrains.kotlin.idea.util.projectStructure` internal APIs to IntelliJ Platform APIs.
+- Fix: Migrate GAV `//DEPS` completion from the removed `reposearch` `DependencySearchService` to the new `DependencyCompletionService`.
+- Build: Migrate to IntelliJ Platform Gradle Plugin 2.x. Minimum supported IDE is now 2026.2 (build 262, JBR 25).
+
 
 ## 0.25.2
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,128 +1,97 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
-    // Java support
     id("java")
-    // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.9.24"
-    // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.17.4"
-    // Gradle Changelog Plugin
+    id("org.jetbrains.kotlin.jvm") version "2.4.0"
+    // IntelliJ Platform Gradle Plugin 2.x (required for IntelliJ Platform 2024.2+)
+    id("org.jetbrains.intellij.platform") version "2.10.5"
     id("org.jetbrains.changelog") version "2.2.1"
-    // Gradle Qodana Plugin
-    //id("org.jetbrains.qodana") version "2023.3.1"
 }
 
-group = properties("pluginGroup")
-version = properties("pluginVersion")
+group = providers.gradleProperty("pluginGroup").get()
+version = providers.gradleProperty("pluginVersion").get()
 
-// Configure project's dependencies
 repositories {
     mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 dependencies {
     implementation("org.zeroturnaround:zt-exec:1.12")
+
+    intellijPlatform {
+        intellijIdea(providers.gradleProperty("platformVersion"))
+        bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
+        bundledModules(providers.gradleProperty("platformBundledModules").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
+    }
 }
 
 configurations.implementation {
     exclude(group = "org.slf4j", module = "slf4j-api")
 }
 
-// Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-intellij {
-    pluginName.set(properties("pluginName"))
-    version.set(properties("platformVersion"))
-    type.set(properties("platformType"))
-
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+// IntelliJ IDEA 2026.2 runs on JBR 25.
+kotlin {
+    jvmToolchain(25)
 }
 
-// Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-changelog {
-    version.set(properties("pluginVersion"))
-    groups.set(emptyList())
-}
-
-tasks {
-    // Set the JVM compatibility versions
-    properties("javaVersion").let {
-        withType<JavaCompile> {
-            sourceCompatibility = it
-            targetCompatibility = it
-        }
-        withType<KotlinCompile> {
-            kotlinOptions.jvmTarget = it
-        }
-    }
-
-    wrapper {
-        gradleVersion = properties("gradleVersion")
-    }
-
-    patchPluginXml {
-        version.set(properties("pluginVersion"))
-        sinceBuild.set(properties("pluginSinceBuild"))
-        untilBuild.set(properties("pluginUntilBuild"))
+intellijPlatform {
+    pluginConfiguration {
+        name = providers.gradleProperty("pluginName")
+        version = providers.gradleProperty("pluginVersion")
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription.set(
-            projectDir.resolve("README.md").readText().lines().run {
-                val start = "<!-- Plugin description -->"
-                val end = "<!-- Plugin description end -->"
+        description = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
+            val start = "<!-- Plugin description -->"
+            val end = "<!-- Plugin description end -->"
 
+            with(it.lines()) {
                 if (!containsAll(listOf(start, end))) {
                     throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
                 }
-                subList(indexOf(start) + 1, indexOf(end))
-            }.joinToString("\n").run { markdownToHTML(this) }
-        )
+                subList(indexOf(start) + 1, indexOf(end)).joinToString("\n").let(::markdownToHTML)
+            }
+        }
 
         // Get the latest available change notes from the changelog file
-        changeNotes.set(provider {
-            changelog.renderItem(
-                changelog
-                    .getLatest()
-                    .withHeader(false)
-                    .withEmptySections(false),
-                Changelog.OutputType.HTML
-            )
-        })
+        val changelog = project.changelog
+        changeNotes = providers.gradleProperty("pluginVersion").map { pluginVersion ->
+            with(changelog) {
+                renderItem(
+                    (getOrNull(pluginVersion) ?: getUnreleased())
+                        .withHeader(false)
+                        .withEmptySections(false),
+                    Changelog.OutputType.HTML,
+                )
+            }
+        }
+
+        ideaVersion {
+            sinceBuild = providers.gradleProperty("pluginSinceBuild")
+        }
     }
 
-    // Configure UI tests plugin
-    // Read more: https://github.com/JetBrains/intellij-ui-test-robot
-    runIdeForUiTests {
-        systemProperty("robot-server.port", "8082")
-        systemProperty("ide.mac.message.dialogs.as.sheets", "false")
-        systemProperty("jb.privacy.policy.text", "<!--999.999-->")
-        systemProperty("jb.consents.confirmation.enabled", "false")
+    signing {
+        certificateChain = providers.environmentVariable("CERTIFICATE_CHAIN")
+        privateKey = providers.environmentVariable("PRIVATE_KEY")
+        password = providers.environmentVariable("PRIVATE_KEY_PASSWORD")
     }
 
-    /*runPluginVerifier {
-        verifierVersion.set("1.307")
-        // DEPRECATED_API_USAGES
-        failureLevel.set(listOf(NOT_DYNAMIC, INVALID_PLUGIN))
-    }*/
-
-    signPlugin {
-        certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
-        privateKey.set(System.getenv("PRIVATE_KEY"))
-        password.set(System.getenv("PRIVATE_KEY_PASSWORD"))
+    publishing {
+        token = providers.environmentVariable("PUBLISH_TOKEN")
+        channels = providers.gradleProperty("pluginVersion").map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
     }
 
-    publishPlugin {
-        dependsOn("patchChangelog")
-        token.set(System.getenv("PUBLISH_TOKEN"))
-        // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
-        // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
-        // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels = providers.gradleProperty("pluginVersion")
-            .map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
-    }
+    // The searchable-options index is built by launching a headless IDE, which fails to start under the
+    // 2026.2 JBR (`-javaagent` instrumentation error). The index is optional, so skip it.
+    buildSearchableOptions = false
+}
+
+changelog {
+    version = providers.gradleProperty("pluginVersion")
+    groups.empty()
+    repositoryUrl = providers.gradleProperty("pluginRepositoryUrl")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,13 +21,14 @@ repositories {
 
 dependencies {
     implementation("org.zeroturnaround:zt-exec:1.12")
+    testImplementation("junit:junit:4.13.2")
 
     intellijPlatform {
         intellijIdea(providers.gradleProperty("platformVersion"))
         bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
         bundledModules(providers.gradleProperty("platformBundledModules").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
 
-        testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Bundled)
+        testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Platform)
         testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Plugin.Java)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,8 @@ dependencies {
         bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
         bundledModules(providers.gradleProperty("platformBundledModules").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
 
-        testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Platform)
+        testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.JUnit4)
+        testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Plugin.Java)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "2.4.0"
     // IntelliJ Platform Gradle Plugin 2.x (required for IntelliJ Platform 2024.2+)
-    id("org.jetbrains.intellij.platform") version "2.18.1"
+    id("org.jetbrains.intellij.platform") version "2.17.0"
     id("org.jetbrains.changelog") version "2.2.1"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
         intellijIdea(providers.gradleProperty("platformVersion"))
         bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
         bundledModules(providers.gradleProperty("platformBundledModules").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
+
+        testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Platform)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "2.4.0"
     // IntelliJ Platform Gradle Plugin 2.x (required for IntelliJ Platform 2024.2+)
-    id("org.jetbrains.intellij.platform") version "2.10.5"
+    id("org.jetbrains.intellij.platform") version "2.18.1"
     id("org.jetbrains.changelog") version "2.2.1"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
         bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
         bundledModules(providers.gradleProperty("platformBundledModules").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
 
-        testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.JUnit4)
+        testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Bundled)
         testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Plugin.Java)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "2.4.0"
     // IntelliJ Platform Gradle Plugin 2.x (required for IntelliJ Platform 2024.2+)
-    id("org.jetbrains.intellij.platform") version "2.17.0"
+    id("org.jetbrains.intellij.platform") version "2.18.1"
     id("org.jetbrains.changelog") version "2.2.1"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,25 +3,22 @@
 
 pluginGroup = dev.jbang.intellij.plugins
 pluginName = jbang-idea-plugin
+pluginRepositoryUrl = https://github.com/jbangdev/jbang-idea
 # SemVer format -> https://semver.org
 pluginVersion = 0.25.2
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-# for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 233
+# 262 = 2026.2, the first build where this plugin's platform APIs are available.
+pluginSinceBuild = 262
 # leaving blank to make installable in EAP
 pluginUntilBuild =
 
-# IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
-platformType = IC
-platformVersion = 2023.3.4
+# IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html
+platformVersion = 2026.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-# Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.intellij.java,org.jetbrains.kotlin,org.intellij.groovy,com.intellij.gradle,org.jetbrains.idea.reposearch
-
-# Java language level used to compile sources and to generate the plugin files - Java 17 is required since 2022.3
-javaVersion = 17
+platformBundledPlugins = com.intellij.java,com.intellij.modules.json,org.jetbrains.idea.reposearch,org.jetbrains.kotlin,org.intellij.groovy,com.intellij.gradle
+platformBundledModules = intellij.repository.search.completion
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.14.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ platformBundledPlugins = com.intellij.java,com.intellij.modules.json,org.jetbrai
 platformBundledModules = intellij.repository.search.completion
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.14.4
+gradleVersion = 9.6.1
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = dev.jbang.intellij.plugins
 pluginName = jbang-idea-plugin
 pluginRepositoryUrl = https://github.com/jbangdev/jbang-idea
 # SemVer format -> https://semver.org
-pluginVersion = 0.25.2
+pluginVersion = 0.26.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # 262 = 2026.2, the first build where this plugin's platform APIs are available.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "jbang-idea-plugin"

--- a/src/main/kotlin/dev/jbang/idea/JBangCli.kt
+++ b/src/main/kotlin/dev/jbang/idea/JBangCli.kt
@@ -10,7 +10,7 @@ import dev.jbang.idea.JBangCli.parentEnvironment
 import org.zeroturnaround.exec.ProcessExecutor
 import java.io.File
 
-public val PARENT_ENV_VAR = parentEnvironment();
+public val PARENT_ENV_VAR by lazy { parentEnvironment() }
 
 object JBangCli {
 

--- a/src/main/kotlin/dev/jbang/idea/actions/SyncDependenciesAction.kt
+++ b/src/main/kotlin/dev/jbang/idea/actions/SyncDependenciesAction.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.externalSystem.importing.ImportSpecBuilder
 import com.intellij.openapi.externalSystem.util.ExternalSystemUtil
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
@@ -25,13 +26,10 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.pom.java.LanguageLevel
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
 import dev.jbang.idea.*
 import dev.jbang.idea.JBangCli.resolveScriptDependencies
 import dev.jbang.idea.JBangCli.resolveScriptInfo
-import org.jetbrains.kotlin.idea.core.util.toPsiFile
-import org.jetbrains.kotlin.idea.util.module
-import org.jetbrains.kotlin.idea.util.projectStructure.getModuleDir
-import org.jetbrains.kotlin.idea.util.projectStructure.version
 import org.jetbrains.plugins.gradle.util.GradleConstants
 
 
@@ -70,17 +68,17 @@ class SyncDependenciesAction : AnAction() {
         if (jbangScriptFile != null && isJBangScriptFile(jbangScriptFile.name)) {
             if (isJBangScript(jbangScriptFile.text)) {
                 val project = e.getData(CommonDataKeys.PROJECT)!!
-                val module = jbangScriptFile.module
+                val module = ModuleUtilCore.findModuleForPsiElement(jbangScriptFile)
                 if (module != null) {
                     var buildGradle = LocalFileSystem.getInstance().findFileByPath(project.basePath + "/build.gradle")
                     var moduleBuildGradle = false
-                    val buildGradleOfModule = LocalFileSystem.getInstance().findFileByPath(module.getModuleDir() + "/build.gradle")
+                    val buildGradleOfModule = LocalFileSystem.getInstance().findFileByPath(ModuleUtilCore.getModuleDirPath(module) + "/build.gradle")
                     if (buildGradleOfModule != null) {
                         buildGradle = buildGradleOfModule
                         moduleBuildGradle = true
                     }
                     if (buildGradle != null) { // sync dependencies between DEPS and gradle
-                        syncDependenciesBetweenJBangAndGradle(project, module, buildGradle.toPsiFile(project)!!, jbangScriptFile, moduleBuildGradle)
+                        syncDependenciesBetweenJBangAndGradle(project, module, PsiManager.getInstance(project).findFile(buildGradle)!!, jbangScriptFile, moduleBuildGradle)
                     } else { //sync DEPS to IDEA's module
                         syncDepsToModule(module, jbangScriptFile)
                     }
@@ -333,7 +331,7 @@ class SyncDependenciesAction : AnAction() {
         if (moduleSdk == null || moduleSdk.name != version) {
             val javaSdk = checkIfSdkExistsIfNotSyncWithJbang(version, module)
             if (javaSdk != null) {
-                val languageLevel = LanguageLevel.valueOf(javaSdk.version?.name!!)
+                val languageLevel = LanguageLevel.valueOf(JavaSdk.getInstance().getVersion(javaSdk)?.name!!)
                 ApplicationManager.getApplication().runWriteAction {
                     val modifiableRootModel = moduleRootManager.modifiableModel
                     modifiableRootModel.sdk = javaSdk

--- a/src/main/kotlin/dev/jbang/idea/completion/deps/JBangDepsGavBaseCompletionContributor.kt
+++ b/src/main/kotlin/dev/jbang/idea/completion/deps/JBangDepsGavBaseCompletionContributor.kt
@@ -2,19 +2,19 @@ package dev.jbang.idea.completion.deps
 
 import com.intellij.codeInsight.completion.*
 import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.components.service
+import com.intellij.openapi.externalSystem.model.ProjectSystemId
+import com.intellij.openapi.progress.runBlockingCancellable
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiComment
+import com.intellij.repository.search.completion.api.DependencyCompletionContextImpl
+import com.intellij.repository.search.completion.api.DependencyCompletionEvent
+import com.intellij.repository.search.completion.api.DependencyCompletionRequest
+import com.intellij.repository.search.completion.api.DependencyCompletionService
+import com.intellij.repository.search.completion.api.DependencyVersionCompletionRequest
 import com.intellij.util.ProcessingContext
 import dev.jbang.idea.mavenIcon
-import org.jetbrains.concurrency.Promise.State.PENDING
-import org.jetbrains.idea.maven.onlinecompletion.model.MavenRepositoryArtifactInfo
-import org.jetbrains.idea.reposearch.DependencySearchService
-import org.jetbrains.idea.reposearch.RepositoryArtifactData
-import org.jetbrains.idea.reposearch.SearchParameters
-import java.util.concurrent.ConcurrentLinkedDeque
-import java.util.function.Consumer
 
 @Suppress("UnstableApiUsage")
 open class JBangDepsGavBaseCompletionContributor : CompletionContributor(), DumbAware {
@@ -26,49 +26,48 @@ open class JBangDepsGavBaseCompletionContributor : CompletionContributor(), Dumb
             result: CompletionResultSet
         ) {
             val comment = parameters.position as PsiComment
-            if (comment.text.startsWith("//DEPS ")) {
-                val searchText = trimDummy(comment.text.substring(7).trim())
-                val startOffset = comment.textRange.startOffset + 7
-                val searchService = DependencySearchService.getInstance(comment.project)
-                val searchParameters = SearchParameters(parameters.invocationCount < 2, false)
-                val cld = ConcurrentLinkedDeque<RepositoryArtifactData>()
-                val parts = searchText.split(':')
-                val searchVersion = parts.size == 3
-                val promise = if (parts.size < 2) {
-                    searchService.fulltextSearch(searchText, searchParameters, Consumer { cld.add(it) })
-                } else {
-                    searchService.suggestPrefix(parts[0], parts[1], searchParameters, Consumer { cld.add(it) })
-                }
-                while (promise.state === PENDING || !cld.isEmpty()) {
-                    ProgressManager.checkCanceled()
-                    val item = cld.poll()
-                    if (item != null && item is MavenRepositoryArtifactInfo) {
-                        val lookupString = if (searchVersion) {
-                            item.version.toString()
-                        } else {
-                            if (item.version != null) {
-                                "${item.key}:${item.version}"
-                            } else {
-                                item.key
+            if (!comment.text.startsWith("//DEPS ")) return
+            val searchText = trimDummy(comment.text.substring(7).trim())
+            val startOffset = comment.textRange.startOffset + 7
+            val parts = searchText.split(':')
+            val searchVersion = parts.size == 3
+
+            val searchService = service<DependencyCompletionService>()
+            val searchContext = DependencyCompletionContextImpl(comment.project, ProjectSystemId("GRADLE"))
+
+            fun addLookup(lookupString: String) {
+                result.addElement(
+                    LookupElementBuilder.create(searchText, lookupString).withIcon(mavenIcon)
+                        .withInsertHandler { insertionContext, selectedItem ->
+                            var selectedText = selectedItem.lookupString
+                            if (searchVersion) {
+                                val artifactInfo = searchText.substring(0, searchText.lastIndexOf(':'))
+                                selectedText = "$artifactInfo:$selectedText"
                             }
+                            // replace GAV because some special characters(`[:-_]`) make code completion not inserted correctly
+                            val editor = insertionContext.editor
+                            val document = insertionContext.document
+                            val currentOffset = editor.caretModel.offset
+                            document.deleteString(startOffset, currentOffset)
+                            document.insertString(startOffset, selectedText)
+                            editor.caretModel.moveToOffset(startOffset + selectedText.length)
                         }
-                        result.addElement(
-                            LookupElementBuilder.create(searchText, lookupString).withIcon(mavenIcon)
-                                .withInsertHandler { insertionContext, selectedItem ->
-                                    var selectedText = selectedItem.lookupString
-                                    if (searchVersion) {
-                                        val artifactInfo = searchText.substring(0, searchText.lastIndexOf(':'))
-                                        selectedText = "$artifactInfo:$selectedText"
-                                    }
-                                    // replace GAV because some special characters(`[:-_]`) that make code completion not inserted correctly
-                                    val editor = insertionContext.editor
-                                    val document = insertionContext.document
-                                    val currentOffset = editor.caretModel.offset
-                                    document.deleteString(startOffset, currentOffset)
-                                    document.insertString(startOffset, selectedText)
-                                    editor.caretModel.moveToOffset(startOffset + selectedText.length)
-                                }
-                        )
+                )
+            }
+
+            runBlockingCancellable {
+                if (searchVersion) {
+                    val request = DependencyVersionCompletionRequest(parts[0], parts[1], parts[2], searchContext)
+                    searchService.suggestVersionCompletions(request).collect { event ->
+                        if (event is DependencyCompletionEvent.Item) addLookup(event.result.result)
+                    }
+                } else {
+                    val request = DependencyCompletionRequest(searchText, searchContext)
+                    searchService.suggestCompletions(request).collect { event ->
+                        if (event is DependencyCompletionEvent.Item) {
+                            val item = event.result
+                            addLookup("${item.groupId}:${item.artifactId}:${item.version}")
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/dev/jbang/idea/externalsystem/JBangDependencyModifier.kt
+++ b/src/main/kotlin/dev/jbang/idea/externalsystem/JBangDependencyModifier.kt
@@ -8,8 +8,8 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.openapi.module.Module
 import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiManager
 import dev.jbang.idea.file.JBangScriptFileIndex
-import org.jetbrains.kotlin.idea.core.util.toPsiFile
 import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
 
 @Suppress("UnstableApiUsage")
@@ -43,7 +43,7 @@ class JBangDependencyModifier : ExternalDependencyModificator {
     override fun declaredDependencies(module: Module): MutableList<DeclaredDependency> {
         val scriptFiles = JBangScriptFileIndex.findJbangScriptFiles(module)
         return scriptFiles.map {
-            it.toPsiFile(module.project)!!
+            PsiManager.getInstance(module.project).findFile(it)!!
         }.flatMap { psiFile ->
             psiFile.getChildrenOfType<PsiComment>().filter { it.text.startsWith("//DEPS ") }
                 .map { psiComment ->

--- a/src/main/kotlin/dev/jbang/idea/file/JBangScriptFileIndex.kt
+++ b/src/main/kotlin/dev/jbang/idea/file/JBangScriptFileIndex.kt
@@ -43,7 +43,7 @@ class JBangScriptFileIndex : ScalarIndexExtension<String>() {
     }
 
     companion object {
-        val NAME = ID.create<String, Void?>("jbang.scriptFileIndex")
+        val NAME = ID.create<String, Void>("jbang.scriptFileIndex")
 
         fun findJbangScriptFiles(module: Module): MutableCollection<VirtualFile> {
             val fileBasedIndex = FileBasedIndex.getInstance()

--- a/src/main/kotlin/dev/jbang/idea/module/JBangModuleBuilder.kt
+++ b/src/main/kotlin/dev/jbang/idea/module/JBangModuleBuilder.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ModuleRootManager
 import dev.jbang.idea.JBangCli.generateScriptFromTemplate
 import dev.jbang.idea.jbangIcon
-import org.jetbrains.kotlin.idea.util.projectStructure.sdk
 import java.util.*
 import java.util.regex.Pattern
 import javax.swing.Icon
@@ -36,7 +35,7 @@ class JBangModuleBuilder : JavaModuleBuilder(), ModuleBuilderListener {
         val moduleRootManager = ModuleRootManager.getInstance(module)
         val properties = Properties()
         properties.putAll(FileTemplateManager.getInstance(module.project).defaultProperties)
-        val javaSdkVersion = module.sdk?.versionString
+        val javaSdkVersion = moduleRootManager.sdk?.versionString
         val javaVersion = if (javaSdkVersion != null) {
             (19 downTo 9).firstOrNull { javaSdkVersion.contains("${it}.0") } ?: 8
         } else {

--- a/src/main/kotlin/dev/jbang/idea/navigation/ScriptRefNavigation.kt
+++ b/src/main/kotlin/dev/jbang/idea/navigation/ScriptRefNavigation.kt
@@ -4,8 +4,8 @@ import com.intellij.navigation.DirectNavigationProvider
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
 import dev.jbang.idea.completion.ScriptRefCompletionContributor.Companion.scriptRefValueCapture
-import org.jetbrains.kotlin.idea.core.util.toPsiFile
 
 
 @Suppress("UnstableApiUsage")
@@ -19,7 +19,7 @@ class ScriptRefNavigation : DirectNavigationProvider {
             ) {
                 val directory = element.containingFile.parent as PsiDirectory
                 val realPath = directory.virtualFile.toNioPath().resolve(scriptRef)
-                return VirtualFileManager.getInstance().findFileByNioPath(realPath)?.toPsiFile(element.project)
+                return VirtualFileManager.getInstance().findFileByNioPath(realPath)?.let { PsiManager.getInstance(element.project).findFile(it) }
             }
         }
         return null

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -76,7 +76,7 @@
             </action>
             <action id="JBang.Run" description="Run JBang Script"
                     class="dev.jbang.idea.ui.toolbar.RunScriptAction"
-                    icon="AllIcons.Actions.Run_anything" text="Run JBang Script">
+                    icon="AllIcons.Actions.Execute" text="Run JBang Script">
             </action>
         </group>
     </actions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,6 +6,7 @@
     <category>Tool</category>
 
     <depends>com.intellij.modules.java</depends>
+    <depends>com.intellij.modules.json</depends>
     <depends>org.jetbrains.idea.reposearch</depends>
     <depends optional="true" config-file="jbang-withKotlin.xml">org.jetbrains.kotlin</depends>
     <depends optional="true" config-file="jbang-withGroovy.xml">org.intellij.groovy</depends>


### PR DESCRIPTION
## Problem

IntelliJ IDEA 2026.2 removed several internal APIs this plug-in used, so JBang 0.25.2 breaks at runtime on 2026.2. The clearest symptom is **Sync Dependencies** throwing `NoClassDefFoundError: org/jetbrains/kotlin/idea/util/projectStructure/ProjectStructureUtilKt` (#155). GAV `//DEPS` completion and file indexing hit removed APIs too.

## Changes

Source:
- Replace the removed `org.jetbrains.kotlin.idea.util.projectStructure` helpers (`getModuleDir`, `version`, `sdk`) and the sibling internals (`toPsiFile`, `PsiElement.module`) with IntelliJ Platform APIs (`ModuleUtilCore`, `PsiManager`, `JavaSdk`, `ModuleRootManager`).
- Rewrite GAV `//DEPS` completion off the removed reposearch `DependencySearchService` / `MavenRepositoryArtifactInfo` onto `DependencyCompletionService` (`suggestCompletions` for coordinates, `suggestVersionCompletions` for versions).
- Adapt `JBangScriptFileIndex` to the tightened `FileBasedIndex.ID` generics.
- Depend on the JSON plug-in (`com.intellij.modules.json`), now that JSON is a separate bundled plug-in.

Build:
- Move to the IntelliJ Platform Gradle Plugin 2.x, target 2026.2, Kotlin 2.4, JVM toolchain 25 (2026.2 runs on JBR 25).
- Minimum supported build is now 262. These platform APIs don't exist on older releases, so this drops pre-2026.2 support. Related to #141.

## Testing

`./gradlew buildPlugin` passes against the 2026.2 SDK (compile, `instrumentCode`, package). `buildSearchableOptions` is off because its headless IDE fails to start under the 2026.2 JBR (`-javaagent` error); that index is optional.

I installed the built plug-in in IntelliJ IDEA 2026.2 (IU-262.8665.258, the build from #155) and checked it live: it loads, all migrated classes link, **Sync Dependencies** runs on a `//DEPS` script with no `NoClassDefFoundError`, `DependencyCompletionService` resolves at runtime, and `//DEPS org.apache.commons:commons-lang3` resolves to its jar through the JBang CLI.

Fixes #155
