### PR TITLE
feat: support template property overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### Added
+- Template creation now displays declared template properties in an IntelliJ-style key/value
+  table, resolves free-form catalog-qualified template IDs, reports the exact resolved template
+  and catalog, and passes user overrides to `jbang init` ([#46](https://github.com/jbangdev/jbang-idea/issues/46)).
+
 ### Changed
 - Run/Debug configurations now use IntelliJ's standard parameter controls, including macro
   expansion, structured environment variables, parent-environment selection, and consistent

--- a/docs/modules/ROOT/pages/features.adoc
+++ b/docs/modules/ROOT/pages/features.adoc
@@ -77,7 +77,10 @@ image:current/external-libraries.png[JBang JDK and dependency overlay under Exte
 == Creating scripts
 
 Choose *New > JBang Script* in the Project view to load templates from the JBang CLI.
-Select a template, edit the suggested filename, and create the script with `jbang init` without leaving the IDE.
+Select a template or enter a catalog-qualified ID such as `template@catalog`. The plugin resolves qualified
+IDs against that catalog, loads their declared properties, and reports the exact resolved template and catalog.
+Edit the suggested filename and property values as needed; the plugin passes only changed values to
+`jbang init` and leaves unchanged defaults to JBang.
 
 image:current/create-script.png[Creating a JBang script from a template]
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -128,8 +128,12 @@ image:current/external-libraries.png[Root-specific Java version and dependency o
 == Creating scripts
 
 In the Project view, choose *New > JBang Script*.
-The plugin loads templates from `jbang template list`, asks for a template, suggests a filename such as `readme.md`, `hello.kt`, or `<template>.java`, and creates the file with `jbang init`.
-The filename remains editable before creation.
+The plugin loads templates and their declared properties from `jbang template list`, asks for a template,
+suggests a filename such as `readme.md`, `hello.kt`, or `<template>.java`, and creates the file with `jbang init`.
+The filename remains editable before creation. You can also enter a catalog-qualified template ID such as
+`q-aws-lambda@jbang-cloud` directly. The plugin resolves it against the named catalog, reports the exact
+resolved template and catalog, and loads its property descriptions and defaults into the key/value table.
+Only changed values are passed to `jbang init` as `-Dkey=value` overrides.
 
 image:current/create-script.png[Creating a script from a JBang template]
 

--- a/src/main/kotlin/dev/jbang/idea/JBangCreateScriptAction.kt
+++ b/src/main/kotlin/dev/jbang/idea/JBangCreateScriptAction.kt
@@ -34,18 +34,24 @@ class JBangCreateScriptAction : DumbAwareAction() {
                 if (!dialog.showAndGet()) return
                 val name = dialog.scriptName
                 val template = dialog.selectedTemplate
-                create(project, directory, name, template)
+                create(project, directory, name, template, dialog.propertyOverrides)
             }
         }.queue()
     }
 
-    private fun create(project: com.intellij.openapi.project.Project, directory: VirtualFile, name: String, template: String?) {
+    private fun create(
+        project: com.intellij.openapi.project.Project,
+        directory: VirtualFile,
+        name: String,
+        template: String?,
+        properties: Map<String, String>,
+    ) {
         object : Task.Backgroundable(project, "Creating JBang script", true) {
             private var error: Exception? = null
             override fun run(indicator: ProgressIndicator) {
                 try {
                     val path = File(directory.path, name).path
-                    JBangCli.initScript(path, template)
+                    JBangCli.initScript(path, template, properties)
                 } catch (e: Exception) {
                     error = e
                 }
@@ -62,11 +68,13 @@ class JBangCreateScriptAction : DumbAwareAction() {
     }
 
     companion object {
-        internal fun suggestFileName(template: String?): String =
-            when {
-                template == null -> ""
-                listOf(".java", ".kt", ".groovy", ".jsh", ".md").any(template::endsWith) -> template
-                else -> "$template.java"
+        internal fun suggestFileName(template: String?): String {
+            val templateName = template?.substringBefore('@')
+            return when {
+                templateName == null -> ""
+                listOf(".java", ".kt", ".groovy", ".jsh", ".md").any(templateName::endsWith) -> templateName
+                else -> "$templateName.java"
             }
+        }
     }
 }

--- a/src/main/kotlin/dev/jbang/idea/JBangCreateScriptDialog.kt
+++ b/src/main/kotlin/dev/jbang/idea/JBangCreateScriptDialog.kt
@@ -1,16 +1,29 @@
 package dev.jbang.idea
 
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.LabeledComponent
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.DocumentAdapter
+import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextField
+import com.intellij.ui.table.TableView
+import com.intellij.util.ui.ColumnInfo
 import com.intellij.util.ui.FormBuilder
+import com.intellij.util.ui.ListTableModel
+import dev.jbang.idea.cli.JBangCli
 import dev.jbang.idea.cli.TemplateInfo
+import dev.jbang.idea.cli.TemplateLookupResult
+import java.awt.BorderLayout
+import javax.swing.JButton
 import javax.swing.JComponent
 import javax.swing.ListSelectionModel
+import javax.swing.JPanel
+import javax.swing.Timer
 import javax.swing.event.DocumentEvent
 
 /**
@@ -18,10 +31,37 @@ import javax.swing.event.DocumentEvent
  * If no template is selected, `jbang init` uses the file extension to pick a default.
  * OK is disabled until a non-blank name is entered.
  */
-class JBangCreateScriptDialog(
+internal fun interface TemplateResolver {
+    fun resolve(reference: String, onResult: (TemplateLookupResult) -> Unit)
+}
+
+private fun backgroundTemplateResolver(project: Project) = TemplateResolver { reference, onResult ->
+    object : Task.Backgroundable(project, "Loading JBang template properties", true) {
+        private lateinit var result: TemplateLookupResult
+
+        override fun run(indicator: ProgressIndicator) {
+            result = JBangCli.lookupTemplate(reference)
+        }
+
+        override fun onSuccess() = onResult(result)
+    }.queue()
+}
+
+internal data class TemplatePropertyRow(
+    val key: String,
+    val description: String,
+    val defaultValue: String?,
+    var value: String,
+)
+
+class JBangCreateScriptDialog internal constructor(
     project: Project,
     templates: List<TemplateInfo>,
+    private val templateResolver: TemplateResolver,
 ) : DialogWrapper(project) {
+
+    constructor(project: Project, templates: List<TemplateInfo>) :
+        this(project, templates, backgroundTemplateResolver(project))
 
     internal val templateList = JBList(templates).apply {
         selectionMode = ListSelectionModel.SINGLE_SELECTION
@@ -37,22 +77,117 @@ class JBangCreateScriptDialog(
         }
     }
 
+    internal val templateField = JBTextField(30).apply {
+        emptyText.text = "template or template@catalog"
+    }
+    internal val templateLookupButton = JButton("Load properties").apply {
+        addActionListener { lookupTypedTemplate() }
+    }
+    internal val templateLookupStatus = JBLabel("Select a template or enter a catalog-qualified ID")
+    private val templateInput = JPanel(BorderLayout(6, 4)).apply {
+        val fieldAndButton = JPanel(BorderLayout(6, 0)).apply {
+            add(templateField, BorderLayout.CENTER)
+            add(templateLookupButton, BorderLayout.EAST)
+        }
+        add(fieldAndButton, BorderLayout.NORTH)
+        add(templateLookupStatus, BorderLayout.SOUTH)
+    }
+    private val templateLookupTimer = Timer(600) { lookupTypedTemplate() }.apply { isRepeats = false }
     internal val nameField = JBTextField(30)
 
-    val selectedTemplate: String? get() = templateList.selectedValue?.name
+    private val propertyColumns: Array<ColumnInfo<TemplatePropertyRow, *>> = arrayOf(
+        object : ColumnInfo<TemplatePropertyRow, String>("Property") {
+            override fun valueOf(item: TemplatePropertyRow) = item.key
+        },
+        object : ColumnInfo<TemplatePropertyRow, String>("Value") {
+            override fun valueOf(item: TemplatePropertyRow) = item.value
+            override fun isCellEditable(item: TemplatePropertyRow) = true
+            override fun setValue(item: TemplatePropertyRow, value: String?) {
+                item.value = value.orEmpty()
+            }
+        },
+        object : ColumnInfo<TemplatePropertyRow, String>("Description") {
+            override fun valueOf(item: TemplatePropertyRow) = item.description
+        },
+    )
+    private val propertyModel = ListTableModel<TemplatePropertyRow>(*propertyColumns)
+    internal val propertyTable: TableView<TemplatePropertyRow> = TableView(propertyModel).apply {
+        emptyText.text = "Select or resolve a template to load declared properties"
+        setMinRowHeight(24)
+    }
+    internal val propertyScrollPane = JBScrollPane(propertyTable).apply {
+        preferredSize = java.awt.Dimension(500, 130)
+    }
+    private val propertyComponent = LabeledComponent.create<JComponent>(
+        propertyScrollPane,
+        "Template properties:",
+    )
+
+    val selectedTemplate: String?
+        get() = templateField.text.trim().ifBlank { null }
     val scriptName: String get() = nameField.text.trim()
+    val propertyOverrides: Map<String, String>
+        get() {
+            propertyTable.stopEditing()
+            return propertyTable.items
+                .filter { it.value != it.defaultValue.orEmpty() }
+                .associateTo(LinkedHashMap()) { it.key to it.value }
+        }
+
+    private var updatingTemplateSelection = false
+    private var templateLookupGeneration = 0
 
     init {
         title = "New JBang Script"
         templateList.addListSelectionListener {
-            if (!it.valueIsAdjusting) {
-                val suggested = JBangCreateScriptAction.suggestFileName(templateList.selectedValue?.name)
-                if (nameField.text.isBlank() || nameField.text == lastSuggested) {
-                    nameField.text = suggested
+            if (!it.valueIsAdjusting && !updatingTemplateSelection) {
+                val template = templateList.selectedValue
+                updatingTemplateSelection = true
+                templateField.text = template?.let(::templateReference).orEmpty()
+                updatingTemplateSelection = false
+                templateLookupTimer.stop()
+                updateSelectedTemplate(template, templateField.text)
+                if (template == null) {
+                    propertyTable.emptyText.text = "Select or resolve a template to load declared properties"
                 }
-                lastSuggested = suggested
+                templateLookupStatus.text = template?.let {
+                    "Selected ${templateReference(it)} from loaded templates"
+                } ?: "Select a template or enter a catalog-qualified ID"
             }
         }
+        templateField.addActionListener { lookupTypedTemplate() }
+        templateField.document.addDocumentListener(object : DocumentAdapter() {
+            override fun textChanged(e: DocumentEvent) {
+                if (updatingTemplateSelection) return
+                templateLookupGeneration++
+                templateLookupButton.isEnabled = true
+                templateLookupStatus.toolTipText = null
+                val reference = templateField.text.trim()
+                val template = templates.find { reference == it.name || reference == templateReference(it) }
+                updatingTemplateSelection = true
+                if (template == null) templateList.clearSelection()
+                else templateList.setSelectedValue(template, true)
+                updatingTemplateSelection = false
+                updateSelectedTemplate(template, reference)
+                templateLookupTimer.stop()
+                if (template != null) {
+                    templateLookupStatus.text = "Selected ${templateReference(template)} from loaded templates"
+                } else if ('@' in reference) {
+                    propertyTable.emptyText.text = "Loading declared properties..."
+                    val templateName = reference.substringBeforeLast('@')
+                    val catalogName = reference.substringAfterLast('@')
+                    templateLookupStatus.text = "Looking for $templateName in catalog $catalogName"
+                    templateLookupTimer.restart()
+                } else {
+                    propertyTable.emptyText.text = "Select or resolve a template to load declared properties"
+                    templateLookupStatus.text = if (reference.isBlank()) {
+                        "Select a template or enter a catalog-qualified ID"
+                    } else {
+                        "Using custom template ID $reference; add @catalog to load declared properties"
+                    }
+                }
+            }
+        })
         nameField.document.addDocumentListener(object : DocumentAdapter() {
             override fun textChanged(e: DocumentEvent) = updateOk()
         })
@@ -62,18 +197,81 @@ class JBangCreateScriptDialog(
 
     private var lastSuggested = ""
 
+    private fun templateReference(template: TemplateInfo): String =
+        template.fullName.ifBlank { template.name }
+
+    private fun updateSelectedTemplate(template: TemplateInfo?, reference: String) {
+        val suggestionSource = template?.name ?: reference.substringBefore('@').ifBlank { null }
+        val suggested = JBangCreateScriptAction.suggestFileName(suggestionSource)
+        if (nameField.text.isBlank() || nameField.text == lastSuggested) {
+            nameField.text = suggested
+        }
+        lastSuggested = suggested
+        updateProperties(template)
+    }
+
+    private fun lookupTypedTemplate() {
+        templateLookupTimer.stop()
+        val reference = templateField.text.trim()
+        if (reference.isBlank() || '@' !in reference) return
+        templateLookupButton.isEnabled = false
+        propertyTable.emptyText.text = "Loading declared properties..."
+        val generation = ++templateLookupGeneration
+        val templateName = reference.substringBeforeLast('@')
+        val catalogName = reference.substringAfterLast('@')
+        templateLookupStatus.text = "Looking for $templateName in catalog $catalogName"
+        templateResolver.resolve(reference) { result ->
+            if (generation != templateLookupGeneration || templateField.text.trim() != reference) return@resolve
+            templateLookupButton.isEnabled = true
+            templateLookupStatus.toolTipText = result.catalogRef
+            val template = result.template
+            updateProperties(template)
+            if (template == null) {
+                propertyTable.emptyText.text = "Properties unavailable because the template could not be resolved"
+            }
+            val resolvedCatalog = result.catalogName ?: catalogName
+            templateLookupStatus.text = if (template != null) {
+                "Resolved ${templateReference(template)} in catalog $resolvedCatalog"
+            } else {
+                "Could not resolve $reference in catalog $resolvedCatalog: ${result.error ?: "template not found"}"
+            }
+        }
+    }
+
+    private fun updateProperties(template: TemplateInfo?) {
+        if (template != null) {
+            propertyTable.emptyText.text = "This template has no declared properties"
+        }
+        val rows = template?.properties.orEmpty().map { (key, property) ->
+            TemplatePropertyRow(
+                key = key,
+                description = property.description,
+                defaultValue = property.defaultValue,
+                value = property.defaultValue.orEmpty(),
+            )
+        }
+        propertyModel.items = rows
+    }
+
     private fun updateOk() {
         isOKActionEnabled = nameField.text.isNotBlank()
     }
 
-    override fun createCenterPanel(): JComponent {
+    public override fun createCenterPanel(): JComponent {
         val scrollPane = JBScrollPane(templateList).apply {
             preferredSize = java.awt.Dimension(400, 200)
         }
         return FormBuilder.createFormBuilder()
-            .addLabeledComponent("Template (optional):", scrollPane)
+            .addLabeledComponent("Available templates:", scrollPane)
+            .addLabeledComponent("Template (optional):", templateInput)
             .addLabeledComponent("File name:", nameField)
+            .addComponent(propertyComponent)
             .panel
+    }
+
+    public override fun dispose() {
+        templateLookupTimer.stop()
+        super.dispose()
     }
 
     override fun doValidate(): ValidationInfo? {

--- a/src/main/kotlin/dev/jbang/idea/cli/JBangCli.kt
+++ b/src/main/kotlin/dev/jbang/idea/cli/JBangCli.kt
@@ -1,6 +1,7 @@
 package dev.jbang.idea.cli
 
 import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
@@ -60,9 +61,30 @@ data class ScriptInfo(
         get() = commandErrors + dependencyErrors + sources.mapNotNull { it.error } + files.mapNotNull { it.error }
 }
 
+data class TemplateProperty(
+    val description: String = "",
+    @SerializedName("default") val defaultValue: String? = null,
+)
+
 data class TemplateInfo(
     val name: String = "",
+    val fullName: String = "",
     val description: String = "",
+    val properties: Map<String, TemplateProperty> = emptyMap(),
+)
+
+data class TemplateLookupResult(
+    val reference: String,
+    val template: TemplateInfo? = null,
+    val catalogName: String? = null,
+    val catalogRef: String? = null,
+    val error: String? = null,
+)
+
+private data class TemplateCatalogInfo(
+    val name: String = "",
+    val resourceRef: String? = null,
+    val templates: List<TemplateInfo> = emptyList(),
 )
 
 private val gson = Gson()
@@ -181,7 +203,7 @@ object JBangCli {
      */
     fun listTemplates(): List<TemplateInfo> {
         return try {
-            val output = exec(findJBangCmd(), "template", "list", "--format=json")
+            val output = exec(*buildTemplateListCommand().toTypedArray())
             gson.fromJson<List<TemplateInfo>>(output, object : TypeToken<List<TemplateInfo>>() {}.type)
         } catch (e: Exception) {
             log.warn("jbang template list failed: ${e.message}")
@@ -189,12 +211,77 @@ object JBangCli {
         }
     }
 
-    /** Calls `jbang init [--template <template>] --force <filePath>`. */
-    fun initScript(filePath: String, templateName: String? = null) {
+    internal fun buildTemplateListCommand(): List<String> =
+        listOf("jbang", "template", "list", "--show-properties", "--format=json")
+
+    fun lookupTemplate(reference: String): TemplateLookupResult {
+        val catalogName = reference.substringAfterLast('@', missingDelimiterValue = "")
+        if (catalogName.isBlank()) {
+            return TemplateLookupResult(reference, error = "Use a catalog-qualified ID such as template@catalog")
+        }
+        return try {
+            val output = exec(*buildTemplateLookupCommand(reference).toTypedArray())
+            parseTemplateLookup(reference, output)
+        } catch (e: Exception) {
+            log.warn("jbang template lookup failed for $reference: ${e.message}")
+            TemplateLookupResult(reference, catalogName = catalogName, error = e.message ?: "Template lookup failed")
+        }
+    }
+
+    internal fun buildTemplateLookupCommand(reference: String): List<String> {
+        val catalogName = reference.substringAfterLast('@', missingDelimiterValue = "")
+        require(catalogName.isNotBlank()) { "Template reference must include @catalog" }
+        return listOf(
+            "jbang", "template", "list", catalogName,
+            "--show-properties", "--show-origin", "--format=json",
+        )
+    }
+
+    internal fun parseTemplateLookup(reference: String, json: String): TemplateLookupResult {
+        val catalogName = reference.substringAfterLast('@', missingDelimiterValue = "")
+        val catalogs = gson.fromJson<List<TemplateCatalogInfo>>(
+            json,
+            object : TypeToken<List<TemplateCatalogInfo>>() {}.type,
+        )
+        val catalog = catalogs.firstOrNull { it.name == catalogName } ?: catalogs.firstOrNull()
+        val templateName = reference.substringBeforeLast('@')
+        val template = catalog?.templates?.firstOrNull {
+            it.fullName == reference || it.name == templateName
+        }
+        return TemplateLookupResult(
+            reference = reference,
+            template = template,
+            catalogName = catalog?.name ?: catalogName,
+            catalogRef = catalog?.resourceRef,
+            error = if (template == null) "Template '$templateName' was not found" else null,
+        )
+    }
+
+    /** Calls `jbang init [properties] [--template <template>] --force <filePath>`. */
+    fun initScript(
+        filePath: String,
+        templateName: String? = null,
+        properties: Map<String, String> = emptyMap(),
+    ) {
         val wsl = if (SystemInfo.isWindows) WslPath.parseWindowsUncPath(filePath) else null
         val effectivePath = wsl?.linuxPath ?: filePath
-        val templateArgs = templateName?.let { arrayOf("--template", it) }.orEmpty()
-        exec("jbang", "init", *templateArgs, "--force", effectivePath, wslDistributionId = wsl?.distributionId)
+        exec(*buildInitCommand(effectivePath, templateName, properties).toTypedArray(), wslDistributionId = wsl?.distributionId)
+    }
+
+    internal fun buildInitCommand(
+        filePath: String,
+        templateName: String? = null,
+        properties: Map<String, String> = emptyMap(),
+    ): List<String> = buildList {
+        add("jbang")
+        add("init")
+        properties.forEach { (key, value) -> add("-D$key=$value") }
+        templateName?.let {
+            add("--template")
+            add(it)
+        }
+        add("--force")
+        add(filePath)
     }
 
     private fun exec(

--- a/src/test/kotlin/dev/jbang/idea/JBangCreateScriptActionTest.kt
+++ b/src/test/kotlin/dev/jbang/idea/JBangCreateScriptActionTest.kt
@@ -2,6 +2,11 @@ package dev.jbang.idea
 
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.ui.table.TableView
+import com.intellij.util.ui.UIUtil
+import dev.jbang.idea.cli.TemplateInfo
+import dev.jbang.idea.cli.TemplateLookupResult
+import dev.jbang.idea.cli.TemplateProperty
 
 class JBangCreateScriptActionTest : BasePlatformTestCase() {
 
@@ -9,6 +14,7 @@ class JBangCreateScriptActionTest : BasePlatformTestCase() {
         assertEquals("readme.md", JBangCreateScriptAction.suggestFileName("readme.md"))
         assertEquals("hello.kt", JBangCreateScriptAction.suggestFileName("hello.kt"))
         assertEquals("qrest.java", JBangCreateScriptAction.suggestFileName("qrest"))
+        assertEquals("qrest.java", JBangCreateScriptAction.suggestFileName("qrest@community"))
     }
 
     fun testNoTemplateSuggestsEmptyFileName() {
@@ -32,6 +38,7 @@ class JBangCreateScriptActionTest : BasePlatformTestCase() {
         val dialog = JBangCreateScriptDialog(project, templates)
 
         dialog.templateList.selectedIndex = 0
+        assertEquals("hello", dialog.templateField.text)
         assertEquals("hello.java", dialog.nameField.text)
 
         dialog.templateList.selectedIndex = 2
@@ -40,6 +47,124 @@ class JBangCreateScriptActionTest : BasePlatformTestCase() {
         // Clearing selection clears the suggested name
         dialog.templateList.clearSelection()
         assertEquals("", dialog.nameField.text)
+    }
+
+    fun testFreeFormTemplateReferenceIsPassedThrough() {
+        val dialog = JBangCreateScriptDialog(
+            project,
+            listOf(TemplateInfo(name = "hello", fullName = "hello@builtins")),
+        )
+        val panel = dialog.createCenterPanel()
+
+        assertTrue(javax.swing.SwingUtilities.isDescendingFrom(dialog.templateField, panel))
+        dialog.templateField.text = "q-aws-lambda@jbang-cloud"
+
+        assertEquals("q-aws-lambda@jbang-cloud", dialog.selectedTemplate)
+        assertTrue("A custom reference must not leave a stale known selection", dialog.templateList.isSelectionEmpty)
+        assertEquals("q-aws-lambda.java", dialog.nameField.text)
+        dialog.dispose()
+    }
+
+    fun testQualifiedTemplateLookupLoadsPropertiesAndShowsResolvedOrigin() {
+        val reference = "q-aws-lambda-sqs-tf@nandorholozsnyak/jbang-cloud"
+        val resolved = TemplateInfo(
+            name = "q-aws-lambda-sqs-tf",
+            fullName = reference,
+            properties = mapOf("aws-sqs-enabled" to TemplateProperty("Generate an SQS queue", "true")),
+        )
+        val dialog = JBangCreateScriptDialog(
+            project,
+            emptyList(),
+            templateResolver = TemplateResolver { requested, onResult ->
+                assertEquals(reference, requested)
+                onResult(
+                    TemplateLookupResult(
+                        reference = reference,
+                        template = resolved,
+                        catalogName = "nandorholozsnyak/jbang-cloud",
+                        catalogRef = "https://github.com/nandorholozsnyak/jbang-cloud/blob/HEAD/jbang-catalog.json",
+                    ),
+                )
+            },
+        )
+
+        dialog.templateField.text = reference
+        assertEquals("Loading declared properties...", dialog.propertyTable.emptyText.text)
+        dialog.templateLookupButton.doClick()
+
+        assertEquals(listOf("aws-sqs-enabled"), dialog.propertyTable.items.map { it.key })
+        assertEquals("true", dialog.propertyTable.items.single().value)
+        assertEquals(
+            "Resolved $reference in catalog nandorholozsnyak/jbang-cloud",
+            dialog.templateLookupStatus.text,
+        )
+        assertEquals(
+            "https://github.com/nandorholozsnyak/jbang-cloud/blob/HEAD/jbang-catalog.json",
+            dialog.templateLookupStatus.toolTipText,
+        )
+    }
+
+    fun testTypingKnownTemplateReferenceLoadsItsProperties() {
+        val template = TemplateInfo(
+            name = "service",
+            fullName = "service@acme",
+            properties = mapOf("region" to TemplateProperty("Deployment region", "eu-central-1")),
+        )
+        val dialog = JBangCreateScriptDialog(project, listOf(template))
+
+        dialog.templateField.text = "service@acme"
+
+        assertEquals(template, dialog.templateList.selectedValue)
+        assertEquals(listOf("region"), dialog.propertyTable.items.map { it.key })
+    }
+
+    fun testTemplatePropertiesUseStandardIntellijTableAndExposeOverrides() {
+        val template = TemplateInfo(
+            name = "service",
+            fullName = "service@acme",
+            description = "Service template",
+            properties = linkedMapOf(
+                "region" to TemplateProperty("Deployment region", "eu-central-1"),
+                "native" to TemplateProperty("Build a native executable", "false"),
+            ),
+        )
+        val dialog = JBangCreateScriptDialog(project, listOf(template))
+
+        assertNotNull(
+            "Template properties should use IntelliJ's standard table control",
+            UIUtil.findComponentOfType(dialog.createCenterPanel(), TableView::class.java),
+        )
+        dialog.templateList.selectedIndex = 0
+
+        assertEquals("service@acme", dialog.selectedTemplate)
+        assertEquals(listOf("region", "native"), dialog.propertyTable.items.map { it.key })
+        assertEquals("eu-central-1", dialog.propertyTable.items[0].value)
+        assertEquals("Deployment region", dialog.propertyTable.items[0].description)
+        assertTrue("Properties table should be visible for a parameterized template", dialog.propertyScrollPane.isVisible)
+        assertTrue("Defaults are handled by JBang and are not overrides", dialog.propertyOverrides.isEmpty())
+
+        dialog.propertyTable.listTableModel.setValueAt("us-east-1", 0, 1)
+
+        assertEquals(mapOf("region" to "us-east-1"), dialog.propertyOverrides)
+    }
+
+    fun testSelectingTemplateWithoutPropertiesClearsPropertyEditor() {
+        val templates = listOf(
+            TemplateInfo(
+                name = "parameterized",
+                properties = mapOf("name" to TemplateProperty("Name", "Duke")),
+            ),
+            TemplateInfo(name = "plain"),
+        )
+        val dialog = JBangCreateScriptDialog(project, templates)
+
+        dialog.templateList.selectedIndex = 0
+        assertTrue(dialog.propertyScrollPane.isVisible)
+        dialog.templateList.selectedIndex = 1
+
+        assertTrue("Keep the dialog layout stable when switching templates", dialog.propertyScrollPane.isVisible)
+        assertTrue(dialog.propertyTable.items.isEmpty())
+        assertTrue(dialog.propertyOverrides.isEmpty())
     }
 
     fun testNoTemplateSelectedAllowsCustomName() {

--- a/src/test/kotlin/dev/jbang/idea/cli/JBangCliParsingTest.kt
+++ b/src/test/kotlin/dev/jbang/idea/cli/JBangCliParsingTest.kt
@@ -134,6 +134,110 @@ class JBangCliParsingTest {
     }
 
     @Test
+    fun `parse template properties with descriptions and defaults`() {
+        val json = """
+        [
+          {
+            "name": "service",
+            "fullName": "service@acme",
+            "description": "Service template",
+            "properties": {
+              "region": {
+                "description": "Deployment region",
+                "default": "eu-central-1"
+              },
+              "native": {
+                "description": "Build a native executable",
+                "default": "false"
+              }
+            }
+          }
+        ]
+        """.trimIndent()
+
+        val template = gson.fromJson(json, Array<TemplateInfo>::class.java).single()
+
+        assertEquals("service@acme", template.fullName)
+        assertEquals("Deployment region", template.properties.getValue("region").description)
+        assertEquals("eu-central-1", template.properties.getValue("region").defaultValue)
+        assertEquals("false", template.properties.getValue("native").defaultValue)
+    }
+
+    @Test
+    fun `template list requests declared properties`() {
+        assertEquals(
+            listOf("jbang", "template", "list", "--show-properties", "--format=json"),
+            JBangCli.buildTemplateListCommand(),
+        )
+    }
+
+    @Test
+    fun `qualified template lookup targets its catalog`() {
+        assertEquals(
+            listOf(
+                "jbang", "template", "list", "nandorholozsnyak/jbang-cloud",
+                "--show-properties", "--show-origin", "--format=json",
+            ),
+            JBangCli.buildTemplateLookupCommand("q-aws-lambda-sqs-tf@nandorholozsnyak/jbang-cloud"),
+        )
+    }
+
+    @Test
+    fun `catalog response resolves qualified template with properties and origin`() {
+        val json = """
+        [
+          {
+            "name": "nandorholozsnyak/jbang-cloud",
+            "resourceRef": "https://github.com/nandorholozsnyak/jbang-cloud/blob/HEAD/jbang-catalog.json",
+            "templates": [
+              {
+                "name": "q-aws-lambda-sqs-tf",
+                "catalogName": "nandorholozsnyak/jbang-cloud",
+                "fullName": "q-aws-lambda-sqs-tf@nandorholozsnyak/jbang-cloud",
+                "properties": {
+                  "aws-sqs-enabled": {
+                    "description": "Generate an SQS queue",
+                    "default": "true"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+        """.trimIndent()
+
+        val result = JBangCli.parseTemplateLookup(
+            "q-aws-lambda-sqs-tf@nandorholozsnyak/jbang-cloud",
+            json,
+        )
+
+        assertEquals("q-aws-lambda-sqs-tf@nandorholozsnyak/jbang-cloud", result.template?.fullName)
+        assertEquals("true", result.template?.properties?.get("aws-sqs-enabled")?.defaultValue)
+        assertEquals("nandorholozsnyak/jbang-cloud", result.catalogName)
+        assertEquals(
+            "https://github.com/nandorholozsnyak/jbang-cloud/blob/HEAD/jbang-catalog.json",
+            result.catalogRef,
+        )
+    }
+
+    @Test
+    fun `init arguments include template property overrides`() {
+        assertEquals(
+            listOf(
+                "jbang", "init",
+                "-Dregion=us-east-1", "-Dnative=true",
+                "--template", "service@acme",
+                "--force", "/tmp/MyService.java",
+            ),
+            JBangCli.buildInitCommand(
+                "/tmp/MyService.java",
+                "service@acme",
+                linkedMapOf("region" to "us-east-1", "native" to "true"),
+            ),
+        )
+    }
+
+    @Test
     fun `unknown fields are ignored`() {
         val json = """
         {


### PR DESCRIPTION
Closes #46.

## What changed

- Request declared template properties from `jbang template list --show-properties --format=json`
- Display property keys, defaults, and descriptions in IntelliJ's standard `TableView`
- Pass only changed values to `jbang init` as `-Dkey=value`
- Accept free-form catalog-qualified IDs such as `q-aws-lambda-sqs-tf@nandorholozsnyak/jbang-cloud`
- Resolve qualified IDs asynchronously against their named catalog
- Show the exact resolved template/catalog and expose the catalog source as a tooltip
- Distinguish loading and lookup failures from templates that genuinely declare no properties
- Document the new creation flow and update the changelog

## Verification

- `./gradlew test --rerun-tasks`
- `./gradlew build`
- Smoke-tested generated `jbang init` property arguments with JBang 0.141.0
- Verified catalog-specific lookup JSON against `nandorholozsnyak/jbang-cloud`