### PR TITLE
fix: resolve jbang.cmd on Windows instead of bash script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   options and working-directory handling in terminal mode.
 
 ### Fixed
+- Windows: `CreateProcess error=193` when running scripts — the plugin resolved to the
+  extensionless `jbang` bash script instead of `jbang.cmd` in `~/.jbang/bin` and `JBANG_HOME`.
 - Run gutter icon now appears on Kotlin class names and `fun main()` declarations, not just
   on directive comments. Previously only Java PSI types were handled ([#164](https://github.com/jbangdev/jbang-idea/issues/164)).
 - Fix crash when syncing from the status bar widget: `saveDocument` was called outside

--- a/src/main/kotlin/dev/jbang/idea/cli/JBangCli.kt
+++ b/src/main/kotlin/dev/jbang/idea/cli/JBangCli.kt
@@ -109,24 +109,41 @@ object JBangCli {
      * Resolves the actual jbang executable path, or null if not found.
      * Checks: settings → JBANG_HOME/bin → ~/.jbang/bin → PATH lookup.
      */
-    fun resolveJBangPath(): String? {
-        val fromSettings = JBangSettings.instance.jbangPath
-        if (fromSettings.isNotBlank() && File(fromSettings).canExecute()) return fromSettings
+    fun resolveJBangPath(): String? = resolveJBangPath(
+        settingsPath = JBangSettings.instance.jbangPath,
+        isWindows = SystemInfo.isWindows,
+        jbangHome = System.getenv("JBANG_HOME"),
+        userHome = System.getProperty("user.home"),
+        pathDirs = System.getenv("PATH")?.split(File.pathSeparatorChar).orEmpty(),
+    )
 
-        val jbangHome = System.getenv("JBANG_HOME")
+    /**
+     * Testable path resolution logic — all environment dependencies injected.
+     */
+    internal fun resolveJBangPath(
+        settingsPath: String,
+        isWindows: Boolean,
+        jbangHome: String?,
+        userHome: String,
+        pathDirs: List<String>,
+    ): String? {
+        if (settingsPath.isNotBlank() && File(settingsPath).canExecute()) return settingsPath
+
+        // On Windows, the extensionless "jbang" file is a bash script that
+        // File.canExecute() matches but CreateProcess cannot run (error=193).
+        // Always prefer jbang.cmd on Windows.
+        val binaryName = if (isWindows) "jbang.cmd" else "jbang"
+
         if (!jbangHome.isNullOrBlank()) {
-            val cmd = File(jbangHome, "bin/jbang").absolutePath
+            val cmd = File(jbangHome, "bin/$binaryName").absolutePath
             if (File(cmd).canExecute()) return cmd
         }
 
-        val userDir = File(System.getProperty("user.home"), ".jbang/bin/jbang")
+        val userDir = File(userHome, ".jbang/bin/$binaryName")
         if (userDir.canExecute()) return userDir.absolutePath
 
-        // Check PATH
-        val pathName = if (SystemInfo.isWindows) "jbang.cmd" else "jbang"
-        val pathDirs = System.getenv("PATH")?.split(File.pathSeparatorChar).orEmpty()
         for (dir in pathDirs) {
-            val candidate = File(dir, pathName)
+            val candidate = File(dir, binaryName)
             if (candidate.canExecute()) return candidate.absolutePath
         }
 

--- a/src/test/kotlin/dev/jbang/idea/cli/JBangCliPathTest.kt
+++ b/src/test/kotlin/dev/jbang/idea/cli/JBangCliPathTest.kt
@@ -1,0 +1,164 @@
+package dev.jbang.idea.cli
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Tests for [JBangCli.resolveJBangPath] — the testable overload that takes
+ * injected environment values so we can simulate Windows/Unix on any OS.
+ */
+class JBangCliPathTest : BasePlatformTestCase() {
+
+    private lateinit var tmpDir: File
+
+    override fun setUp() {
+        super.setUp()
+        tmpDir = Files.createTempDirectory("jbang-path-test").toFile()
+    }
+
+    override fun tearDown() {
+        tmpDir.deleteRecursively()
+        super.tearDown()
+    }
+
+    // --- helpers ---
+
+    /** Create an executable file (or just a regular file on Windows where canExecute is always true). */
+    private fun createExe(parent: File, name: String): File {
+        val f = File(parent, name)
+        f.parentFile.mkdirs()
+        f.writeText("stub")
+        f.setExecutable(true)
+        return f
+    }
+
+    // --- settings path takes priority ---
+
+    fun testSettingsPathWins() {
+        val settingsExe = createExe(tmpDir, "custom/jbang")
+        val homeDir = File(tmpDir, "home")
+        createExe(homeDir, ".jbang/bin/jbang")
+
+        val result = JBangCli.resolveJBangPath(
+            settingsPath = settingsExe.absolutePath,
+            isWindows = false,
+            jbangHome = null,
+            userHome = homeDir.absolutePath,
+            pathDirs = emptyList(),
+        )
+        assertEquals(settingsExe.absolutePath, result)
+    }
+
+    // --- JBANG_HOME takes priority over ~/.jbang ---
+
+    fun testJbangHomeBeforeUserHome() {
+        val jbangHome = File(tmpDir, "jbang-home")
+        val homeDir = File(tmpDir, "home")
+        val expected = createExe(jbangHome, "bin/jbang")
+        createExe(homeDir, ".jbang/bin/jbang")
+
+        val result = JBangCli.resolveJBangPath(
+            settingsPath = "",
+            isWindows = false,
+            jbangHome = jbangHome.absolutePath,
+            userHome = homeDir.absolutePath,
+            pathDirs = emptyList(),
+        )
+        assertEquals(expected.absolutePath, result)
+    }
+
+    // --- Windows: picks jbang.cmd, not the bash script ---
+
+    fun testWindowsPrefersCmd() {
+        val homeDir = File(tmpDir, "home")
+        // Create both files — bash script and .cmd
+        createExe(homeDir, ".jbang/bin/jbang")
+        val cmd = createExe(homeDir, ".jbang/bin/jbang.cmd")
+
+        val result = JBangCli.resolveJBangPath(
+            settingsPath = "",
+            isWindows = true,
+            jbangHome = null,
+            userHome = homeDir.absolutePath,
+            pathDirs = emptyList(),
+        )
+        assertEquals(cmd.absolutePath, result)
+    }
+
+    fun testWindowsJbangHomePicksCmd() {
+        val jbangHome = File(tmpDir, "jbang-home")
+        createExe(jbangHome, "bin/jbang")     // bash script — should be skipped
+        val cmd = createExe(jbangHome, "bin/jbang.cmd")
+
+        val result = JBangCli.resolveJBangPath(
+            settingsPath = "",
+            isWindows = true,
+            jbangHome = jbangHome.absolutePath,
+            userHome = tmpDir.absolutePath,
+            pathDirs = emptyList(),
+        )
+        assertEquals(cmd.absolutePath, result)
+    }
+
+    // --- PATH lookup ---
+
+    fun testPathLookupUnix() {
+        val binDir = File(tmpDir, "usr-bin")
+        val expected = createExe(binDir, "jbang")
+
+        val result = JBangCli.resolveJBangPath(
+            settingsPath = "",
+            isWindows = false,
+            jbangHome = null,
+            userHome = File(tmpDir, "empty-home").absolutePath,
+            pathDirs = listOf(binDir.absolutePath),
+        )
+        assertEquals(expected.absolutePath, result)
+    }
+
+    fun testPathLookupWindows() {
+        val binDir = File(tmpDir, "usr-bin")
+        createExe(binDir, "jbang")          // bash script — skipped
+        val cmd = createExe(binDir, "jbang.cmd")
+
+        val result = JBangCli.resolveJBangPath(
+            settingsPath = "",
+            isWindows = true,
+            jbangHome = null,
+            userHome = File(tmpDir, "empty-home").absolutePath,
+            pathDirs = listOf(binDir.absolutePath),
+        )
+        assertEquals(cmd.absolutePath, result)
+    }
+
+    // --- nothing found ---
+
+    fun testReturnsNullWhenNothingFound() {
+        val result = JBangCli.resolveJBangPath(
+            settingsPath = "",
+            isWindows = false,
+            jbangHome = null,
+            userHome = File(tmpDir, "empty-home").absolutePath,
+            pathDirs = emptyList(),
+        )
+        assertNull(result)
+    }
+
+    // --- Unix: picks extensionless jbang ---
+
+    fun testUnixPicksExtensionless() {
+        val homeDir = File(tmpDir, "home")
+        val expected = createExe(homeDir, ".jbang/bin/jbang")
+        createExe(homeDir, ".jbang/bin/jbang.cmd")  // should be ignored on Unix
+
+        val result = JBangCli.resolveJBangPath(
+            settingsPath = "",
+            isWindows = false,
+            jbangHome = null,
+            userHome = homeDir.absolutePath,
+            pathDirs = emptyList(),
+        )
+        assertEquals(expected.absolutePath, result)
+    }
+}


### PR DESCRIPTION
Fixes #165 (partial — the Windows path resolution part)

## Problem

On Windows, `~/.jbang/bin/` contains both `jbang` (bash script) and `jbang.cmd` (batch file). `resolveJBangPath()` hardcoded `"jbang"` for `JBANG_HOME` and `~/.jbang/bin` lookups. `File.canExecute()` returns true for the bash script on Windows, but `CreateProcess` can't run it → `error=193: %1 is not a valid Win32 application`.

## Fix

Use `jbang.cmd` consistently on Windows for all lookup locations (JBANG_HOME, ~/.jbang/bin, PATH). The PATH check already did this; the other two didn't.

## Tests

Extracted path resolution into a testable internal overload with injected dependencies. 8 tests cover Windows/Unix selection, priority order (settings > JBANG_HOME > ~/.jbang > PATH), and null fallback. The `isWindows=true` tests run on all CI platforms.