### PR TITLE
fix: mirror Kotlin JBang libraries for K2 resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
   extensionless `jbang` bash script instead of `jbang.cmd` in `~/.jbang/bin` and `JBANG_HOME`.
 - Kotlin-compiled dependencies now resolve in standalone JBang scripts under Kotlin K2 mode.
   The active script's Kotlin JARs are mirrored to a module library only when required; Java-only
-  JBang dependencies remain isolated per script ([#165](https://github.com/jbangdev/jbang-idea/issues/165)).
+  JBang dependencies remain isolated per script. The support library is named after its relevant
+  script instead of using the internal “active root” terminology ([#165](https://github.com/jbangdev/jbang-idea/issues/165)).
 - Run gutter icon now appears on Kotlin class names and `fun main()` declarations, not just
   on directive comments. Previously only Java PSI types were handled ([#164](https://github.com/jbangdev/jbang-idea/issues/164)).
 - Fix crash when syncing from the status bar widget: `saveDocument` was called outside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 ### Fixed
 - Windows: `CreateProcess error=193` when running scripts — the plugin resolved to the
   extensionless `jbang` bash script instead of `jbang.cmd` in `~/.jbang/bin` and `JBANG_HOME`.
+- Kotlin-compiled dependencies now resolve in standalone JBang scripts under Kotlin K2 mode.
+  The active script's Kotlin JARs are mirrored to a module library only when required; Java-only
+  JBang dependencies remain isolated per script ([#165](https://github.com/jbangdev/jbang-idea/issues/165)).
 - Run gutter icon now appears on Kotlin class names and `fun main()` declarations, not just
   on directive comments. Previously only Java PSI types were handled ([#164](https://github.com/jbangdev/jbang-idea/issues/164)).
 - Fix crash when syncing from the status bar widget: `saveDocument` was called outside

--- a/src/main/kotlin/dev/jbang/idea/project/JBangAutoSync.kt
+++ b/src/main/kotlin/dev/jbang/idea/project/JBangAutoSync.kt
@@ -177,21 +177,18 @@ internal fun fireLibraryChange(project: Project, completed: () -> Unit = {}) {
         val newRoots = JBangLibraryProvider().getAdditionalProjectLibraries(project)
             .flatMap { it.binaryRoots + it.sourceRoots }
         val oldRoots = project.getUserData(announcedLibraryRoots).orEmpty()
-        if (oldRoots.toSet() == newRoots.toSet()) {
-            WindowManager.getInstance().getStatusBar(project)?.updateWidget("JBangActiveRoot")
-            completed()
-            return@invokeLater
-        }
         com.intellij.openapi.application.runWriteAction {
-            if (!project.isDisposed) {
+            if (project.isDisposed) return@runWriteAction
+            JBangKotlinLibraryMirror.update(project)
+            if (oldRoots.toSet() != newRoots.toSet()) {
                 project.putUserData(announcedLibraryRoots, newRoots)
                 AdditionalLibraryRootsListener.fireAdditionalLibraryChanged(
                     project, /* presentableLibraryName = */ "JBang",
                     oldRoots, newRoots, /* libraryNameForDebug = */ "JBang"
                 )
-                WindowManager.getInstance().getStatusBar(project)?.updateWidget("JBangActiveRoot")
-                completed()
             }
+            WindowManager.getInstance().getStatusBar(project)?.updateWidget("JBangActiveRoot")
+            completed()
         }
     }, ModalityState.nonModal())
 }

--- a/src/main/kotlin/dev/jbang/idea/project/JBangKotlinLibraryMirror.kt
+++ b/src/main/kotlin/dev/jbang/idea/project/JBangKotlinLibraryMirror.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.OrderRootType
@@ -17,7 +18,7 @@ import com.intellij.openapi.vfs.VirtualFile
  * the currently active standalone script only.
  */
 internal object JBangKotlinLibraryMirror {
-    private const val libraryName = "JBang Kotlin (active root)"
+    private const val libraryNamePrefix = "JBang Kotlin support — "
 
     fun update(project: Project, activeRootFile: VirtualFile? = null) {
         val service = JBangProjectService.getInstance(project)
@@ -26,25 +27,33 @@ internal object JBangKotlinLibraryMirror {
         val activeModule = file?.let { ModuleUtilCore.findModuleForFile(it, project) }
         val activeUrls = path?.let(service::getLibraryRoots).orEmpty()
             .filter(::isKotlinLibrary).map(VirtualFile::getUrl)
+        val activeLibraryName = path?.let { libraryNamePrefix + displayPath(project, it) }
 
         // Clean up a previously active root in another module as well.
         ModuleManager.getInstance(project).modules.forEach { module ->
             if (ExternalSystemModulePropertyManager.getInstance(module).getExternalSystemId() == null) {
-                update(module, if (module == activeModule) activeUrls else emptyList())
+                val isActive = module == activeModule && activeUrls.isNotEmpty()
+                update(module, if (isActive) activeUrls else emptyList(), activeLibraryName.takeIf { isActive })
             }
         }
     }
 
-    private fun update(module: Module, urls: List<String>) {
+    private fun update(module: Module, urls: List<String>, libraryName: String?) {
         val rootModel = ModuleRootManager.getInstance(module).modifiableModel
-        val current = rootModel.moduleLibraryTable.getLibraryByName(libraryName)
-            ?.getUrls(OrderRootType.CLASSES)?.toList().orEmpty()
+        val managedLibraries = rootModel.moduleLibraryTable.libraries.filter {
+            it.name?.startsWith(libraryNamePrefix) == true
+        }
+        val unchanged = managedLibraries.size == 1 && managedLibraries.single().let {
+            it.name == libraryName && it.getUrls(OrderRootType.CLASSES).toList() == urls
+        }
         rootModel.dispose()
-        if (current == urls) return
+        if (unchanged) return
 
         ModuleRootModificationUtil.updateModel(module) { model ->
-            model.moduleLibraryTable.getLibraryByName(libraryName)?.let(model.moduleLibraryTable::removeLibrary)
-            if (urls.isNotEmpty()) {
+            model.moduleLibraryTable.libraries
+                .filter { it.name?.startsWith(libraryNamePrefix) == true }
+                .forEach(model.moduleLibraryTable::removeLibrary)
+            if (urls.isNotEmpty() && libraryName != null) {
                 val library = model.moduleLibraryTable.createLibrary(libraryName)
                 model.addLibraryEntry(library)
                 library.modifiableModel.apply {
@@ -53,6 +62,11 @@ internal object JBangKotlinLibraryMirror {
                 }
             }
         }
+    }
+
+    private fun displayPath(project: Project, path: String): String {
+        val basePath = project.guessProjectDir()?.path ?: return path
+        return path.removePrefix("$basePath/").takeIf { it != path } ?: path
     }
 
     private fun isKotlinLibrary(root: VirtualFile): Boolean = root.findFileByRelativePath("META-INF")

--- a/src/main/kotlin/dev/jbang/idea/project/JBangKotlinLibraryMirror.kt
+++ b/src/main/kotlin/dev/jbang/idea/project/JBangKotlinLibraryMirror.kt
@@ -1,0 +1,60 @@
+package dev.jbang.idea.project
+
+import com.intellij.openapi.externalSystem.ExternalSystemModulePropertyManager
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * K2 only creates Kotlin light classes for module-library roots. Keep the
+ * per-script synthetic library as the normal path and mirror Kotlin JARs for
+ * the currently active standalone script only.
+ */
+internal object JBangKotlinLibraryMirror {
+    private const val libraryName = "JBang Kotlin (active root)"
+
+    fun update(project: Project, activeRootFile: VirtualFile? = null) {
+        val service = JBangProjectService.getInstance(project)
+        val path = service.activeRootPath
+        val file = activeRootFile ?: path?.let { LocalFileSystem.getInstance().findFileByPath(it) }
+        val activeModule = file?.let { ModuleUtilCore.findModuleForFile(it, project) }
+        val activeUrls = path?.let(service::getLibraryRoots).orEmpty()
+            .filter(::isKotlinLibrary).map(VirtualFile::getUrl)
+
+        // Clean up a previously active root in another module as well.
+        ModuleManager.getInstance(project).modules.forEach { module ->
+            if (ExternalSystemModulePropertyManager.getInstance(module).getExternalSystemId() == null) {
+                update(module, if (module == activeModule) activeUrls else emptyList())
+            }
+        }
+    }
+
+    private fun update(module: Module, urls: List<String>) {
+        val rootModel = ModuleRootManager.getInstance(module).modifiableModel
+        val current = rootModel.moduleLibraryTable.getLibraryByName(libraryName)
+            ?.getUrls(OrderRootType.CLASSES)?.toList().orEmpty()
+        rootModel.dispose()
+        if (current == urls) return
+
+        ModuleRootModificationUtil.updateModel(module) { model ->
+            model.moduleLibraryTable.getLibraryByName(libraryName)?.let(model.moduleLibraryTable::removeLibrary)
+            if (urls.isNotEmpty()) {
+                val library = model.moduleLibraryTable.createLibrary(libraryName)
+                model.addLibraryEntry(library)
+                library.modifiableModel.apply {
+                    urls.forEach { addRoot(it, OrderRootType.CLASSES) }
+                    commit()
+                }
+            }
+        }
+    }
+
+    private fun isKotlinLibrary(root: VirtualFile): Boolean = root.findFileByRelativePath("META-INF")
+        ?.children.orEmpty().any { it.name.endsWith(".kotlin_module") }
+}

--- a/src/main/kotlin/dev/jbang/idea/project/JBangProjectService.kt
+++ b/src/main/kotlin/dev/jbang/idea/project/JBangProjectService.kt
@@ -152,6 +152,7 @@ class JBangProjectService(private val project: Project) {
     fun setActiveRoot(path: String) {
         activeRootPath = path
         cache[path]?.let { JBangJdkSync.applyToStandaloneProject(project, it) }
+        fireLibraryChange(project)
         updateWidget()
     }
 

--- a/src/test/kotlin/dev/jbang/idea/SampleProjectsTest.kt
+++ b/src/test/kotlin/dev/jbang/idea/SampleProjectsTest.kt
@@ -21,7 +21,9 @@ class SampleProjectsTest {
             "catalog/jbang-catalog.json",
             "catalog/scripts/hello.java",
             "errors/Broken.java",
-            "README.md",
+            "kotlin-deps/KotlinLibrary.java",
+            "kotlin-deps/KotlinLibrary.kt",
+            "README.md", 
         )
 
         expected.forEach { assertTrue("Missing sample: $it", Files.isRegularFile(samples.resolve(it))) }
@@ -29,7 +31,10 @@ class SampleProjectsTest {
 
     @Test
     fun `runnable samples use complete dependency coordinates`() {
-        listOf("single-root/Hello.java", "multi-root/RootA.java", "multi-root/RootB.java").forEach { sample ->
+        listOf(
+            "single-root/Hello.java", "multi-root/RootA.java", "multi-root/RootB.java",
+            "kotlin-deps/KotlinLibrary.java", "kotlin-deps/KotlinLibrary.kt",
+        ).forEach { sample ->
             Files.readAllLines(samples.resolve(sample))
                 .filter { it.startsWith("//DEPS ") }
                 .forEach { directive ->

--- a/src/test/kotlin/dev/jbang/idea/project/JBangLibraryProviderTest.kt
+++ b/src/test/kotlin/dev/jbang/idea/project/JBangLibraryProviderTest.kt
@@ -82,6 +82,42 @@ class JBangLibraryProviderTest : LightJavaCodeInsightFixtureTestCase() {
     }
 
     @Test
+    fun testOnlyKotlinLibrariesAreMirroredToActiveStandaloneModule() {
+        val kotlinJar = Files.createTempFile("jbang-kotlin", ".jar").toFile()
+        JarOutputStream(kotlinJar.outputStream()).use { it.putNextEntry(JarEntry("META-INF/test.kotlin_module")); it.closeEntry() }
+        val javaJar = Files.createTempFile("jbang-java", ".jar").toFile()
+        JarOutputStream(javaJar.outputStream()).use { }
+        val root = myFixture.addFileToProject("KotlinDep.java", "//DEPS example:kotlin:1\nclass KotlinDep {}")
+        installInfo(root.virtualFile.path, ScriptInfo(resolvedDependencies = listOf(kotlinJar.path, javaJar.path)))
+        JBangProjectService.getInstance(project).setActiveRoot(root.virtualFile.path)
+        PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+        assertEquals(module, com.intellij.openapi.module.ModuleUtilCore.findModuleForFile(root.virtualFile, project))
+        assertNull(com.intellij.openapi.externalSystem.ExternalSystemModulePropertyManager.getInstance(module).getExternalSystemId())
+        val kotlinRoot = JBangProjectService.getInstance(project).getLibraryRoots(root.virtualFile.path)
+            .single { it.name == kotlinJar.name }
+        assertNotNull(kotlinRoot.findFileByRelativePath("META-INF/test.kotlin_module"))
+
+        com.intellij.openapi.application.runWriteAction { JBangKotlinLibraryMirror.update(project, root.virtualFile) }
+
+        val rootModel = com.intellij.openapi.roots.ModuleRootManager.getInstance(module).modifiableModel
+        val library = rootModel.moduleLibraryTable.getLibraryByName("JBang Kotlin (active root)")
+        assertNotNull("Kotlin dependencies must be visible to K2 through a module library", library)
+        val roots = library!!.getUrls(com.intellij.openapi.roots.OrderRootType.CLASSES).toList()
+        rootModel.dispose()
+        assertEquals(listOf("jar://${kotlinJar.path}!/"), roots)
+        assertFalse("Plain Java dependencies stay per-script synthetic roots", roots.contains("jar://${javaJar.path}!/"))
+
+        val javaOnly = myFixture.addFileToProject("JavaOnly.java", "//DEPS example:java:1\nclass JavaOnly {}")
+        installInfo(javaOnly.virtualFile.path, ScriptInfo(resolvedDependencies = listOf(javaJar.path)))
+        JBangProjectService.getInstance(project).setActiveRoot(javaOnly.virtualFile.path)
+        com.intellij.openapi.application.runWriteAction { JBangKotlinLibraryMirror.update(project, javaOnly.virtualFile) }
+
+        val afterSwitch = com.intellij.openapi.roots.ModuleRootManager.getInstance(module).modifiableModel
+        assertNull("The Kotlin module library must be removed after leaving its root", afterSwitch.moduleLibraryTable.getLibraryByName("JBang Kotlin (active root)"))
+        afterSwitch.dispose()
+    }
+
+    @Test
     fun testJbangFileResolveScopeIncludesDependencyClasses() {
         val jar = Files.createTempFile("jbang-overlay", ".jar").toFile()
         JarOutputStream(jar.outputStream()).use {

--- a/src/test/kotlin/dev/jbang/idea/project/JBangLibraryProviderTest.kt
+++ b/src/test/kotlin/dev/jbang/idea/project/JBangLibraryProviderTest.kt
@@ -100,12 +100,22 @@ class JBangLibraryProviderTest : LightJavaCodeInsightFixtureTestCase() {
         com.intellij.openapi.application.runWriteAction { JBangKotlinLibraryMirror.update(project, root.virtualFile) }
 
         val rootModel = com.intellij.openapi.roots.ModuleRootManager.getInstance(module).modifiableModel
-        val library = rootModel.moduleLibraryTable.getLibraryByName("JBang Kotlin (active root)")
-        assertNotNull("Kotlin dependencies must be visible to K2 through a module library", library)
+        val library = rootModel.moduleLibraryTable.getLibraryByName("JBang Kotlin support — KotlinDep.java")
+        assertNotNull("Kotlin dependencies must be visible to K2 through a script-specific module library", library)
         val roots = library!!.getUrls(com.intellij.openapi.roots.OrderRootType.CLASSES).toList()
         rootModel.dispose()
         assertEquals(listOf("jar://${kotlinJar.path}!/"), roots)
         assertFalse("Plain Java dependencies stay per-script synthetic roots", roots.contains("jar://${javaJar.path}!/"))
+
+        val otherRoot = myFixture.addFileToProject("nested/OtherKotlinDep.java", "//DEPS example:kotlin:1\nclass OtherKotlinDep {}")
+        installInfo(otherRoot.virtualFile.path, ScriptInfo(resolvedDependencies = listOf(kotlinJar.path)))
+        JBangProjectService.getInstance(project).setActiveRoot(otherRoot.virtualFile.path)
+        com.intellij.openapi.application.runWriteAction { JBangKotlinLibraryMirror.update(project, otherRoot.virtualFile) }
+
+        val afterKotlinSwitch = com.intellij.openapi.roots.ModuleRootManager.getInstance(module).modifiableModel
+        assertNull("The previous script name must not remain visible", afterKotlinSwitch.moduleLibraryTable.getLibraryByName("JBang Kotlin support — KotlinDep.java"))
+        assertNotNull("The library name must identify the relevant script", afterKotlinSwitch.moduleLibraryTable.getLibraryByName("JBang Kotlin support — nested/OtherKotlinDep.java"))
+        afterKotlinSwitch.dispose()
 
         val javaOnly = myFixture.addFileToProject("JavaOnly.java", "//DEPS example:java:1\nclass JavaOnly {}")
         installInfo(javaOnly.virtualFile.path, ScriptInfo(resolvedDependencies = listOf(javaJar.path)))
@@ -113,7 +123,7 @@ class JBangLibraryProviderTest : LightJavaCodeInsightFixtureTestCase() {
         com.intellij.openapi.application.runWriteAction { JBangKotlinLibraryMirror.update(project, javaOnly.virtualFile) }
 
         val afterSwitch = com.intellij.openapi.roots.ModuleRootManager.getInstance(module).modifiableModel
-        assertNull("The Kotlin module library must be removed after leaving its root", afterSwitch.moduleLibraryTable.getLibraryByName("JBang Kotlin (active root)"))
+        assertNull("The Kotlin module library must be removed after leaving its root", afterSwitch.moduleLibraryTable.getLibraryByName("JBang Kotlin support — nested/OtherKotlinDep.java"))
         afterSwitch.dispose()
     }
 

--- a/src/test/kotlin/dev/jbang/idea/project/JBangLibraryProviderTest.kt
+++ b/src/test/kotlin/dev/jbang/idea/project/JBangLibraryProviderTest.kt
@@ -104,7 +104,7 @@ class JBangLibraryProviderTest : LightJavaCodeInsightFixtureTestCase() {
         assertNotNull("Kotlin dependencies must be visible to K2 through a script-specific module library", library)
         val roots = library!!.getUrls(com.intellij.openapi.roots.OrderRootType.CLASSES).toList()
         rootModel.dispose()
-        assertEquals(listOf("jar://${kotlinJar.path}!/"), roots)
+        assertEquals(listOf(kotlinRoot.url), roots)
         assertFalse("Plain Java dependencies stay per-script synthetic roots", roots.contains("jar://${javaJar.path}!/"))
 
         val otherRoot = myFixture.addFileToProject("nested/OtherKotlinDep.java", "//DEPS example:kotlin:1\nclass OtherKotlinDep {}")

--- a/src/test/resources/projects/README.md
+++ b/src/test/resources/projects/README.md
@@ -6,12 +6,13 @@ Open any directory below as a project in the sandbox IDE started by `./gradlew r
 - `multi-root/` — two roots with isolated dependencies; use the JBang status widget to switch context.
 - `catalog/` — Cmd/Ctrl-click the local `script-ref` in `jbang-catalog.json`.
 - `errors/` — intentional unknown directive, invalid and duplicate GAVs, and missing `//SOURCES`/`//FILES` resources.
+- `kotlin-deps/` — Java and Kotlin scripts consuming OpenAI's Kotlin-compiled `OpenAIClient`; open either script and confirm the import resolves.
 
 Useful checks:
 
 - Press Ctrl+Space after `//DEPS`, `//SOURCES`, or `//FILES`.
 - Cmd/Ctrl-click local paths.
 - Confirm dependency types resolve in roots and included sources.
-- Run `RootA.java`, `RootB.java`, `Hello.java`, or the catalog script.
+- Run `RootA.java`, `RootB.java`, `Hello.java`, either `kotlin-deps` script, or the catalog script.
 
 The `errors/` sample is intentionally not runnable.

--- a/src/test/resources/projects/kotlin-deps/KotlinLibrary.java
+++ b/src/test/resources/projects/kotlin-deps/KotlinLibrary.java
@@ -1,0 +1,13 @@
+///usr/bin/env jbang
+//DEPS com.openai:openai-java:4.52.0
+
+// OpenAIClient is compiled from Kotlin and carries kotlin.Metadata.
+// It verifies K2 can expose Kotlin-library light classes to Java JBang scripts.
+import com.openai.client.OpenAIClient;
+
+class KotlinLibrary {
+    public static void main(String[] args) {
+        OpenAIClient client = null;
+        System.out.println("Kotlin dependency resolves: " + client);
+    }
+}

--- a/src/test/resources/projects/kotlin-deps/KotlinLibrary.kt
+++ b/src/test/resources/projects/kotlin-deps/KotlinLibrary.kt
@@ -1,0 +1,10 @@
+#!/usr/bin/env jbang
+//DEPS com.openai:openai-java:4.52.0
+
+// The same Kotlin-compiled dependency, consumed from a Kotlin JBang script.
+import com.openai.client.OpenAIClient
+
+fun main() {
+    val client: OpenAIClient? = null
+    println("Kotlin dependency resolves: $client")
+}

--- a/src/test/resources/projects/kotlin-deps/KotlinLibrary.kt
+++ b/src/test/resources/projects/kotlin-deps/KotlinLibrary.kt
@@ -1,4 +1,5 @@
-#!/usr/bin/env jbang
+///usr/bin/env jbang
+//KOTLIN 1.9.25
 //DEPS com.openai:openai-java:4.52.0
 
 // The same Kotlin-compiled dependency, consumed from a Kotlin JBang script.


### PR DESCRIPTION
Fixes #165.

K2 creates Kotlin light classes only for module-library roots, while JBang normally uses per-script `SyntheticLibrary` roots. This selectively mirrors the active standalone script's JARs containing `META-INF/*.kotlin_module` into a small module library named `JBang Kotlin (active root)`.

- Java-only dependencies remain synthetic and scoped to their owning script.
- The mirror updates (and removes the previous roots) when the active root changes.
- External-system modules are left untouched.
- Regression test asserts that only the Kotlin JAR is attached and that the library is removed after switching to a Java-only root.

Tested: `./gradlew test` (169 tests).
